### PR TITLE
Updated gradle & plugins so piwik-sdk builds on Android Studio 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ jdk: oraclejdk7
 
 android:
   components:
-    - build-tools-19.1.0
-    - android-19
+    - build-tools-22.0.0
+    - android-22
     - extra-android-support
     - extra-android-m2repository
 
-script: ./gradlew :piwik_sdk:test
+script: ./gradlew :piwik_sdk:assemble :piwik_sdk:test
 
 after_success: ./gradlew :piwik_sdk:jacocoTestReport coveralls  --info

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
+        classpath 'com.android.tools.build:gradle:1.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/demo_app/build.gradle
+++ b/demo_app/build.gradle
@@ -13,7 +13,6 @@ android {
     }
     buildTypes {
         release {
-            runProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Mon Mar 16 17:39:56 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/piwik_sdk/build.gradle
+++ b/piwik_sdk/build.gradle
@@ -1,48 +1,52 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
-        classpath 'com.github.jcandksolutions.gradle:android-unit-test:1.6.3'
-    }
-}
-
 apply plugin: 'com.android.library'
 
-
 android {
-    compileSdkVersion 19
-    buildToolsVersion '19.1.0'
+    compileSdkVersion 22
+    buildToolsVersion '22'
 
     defaultConfig {
-        applicationId 'org.piwik.sdk'
         minSdkVersion 7
-        targetSdkVersion 19
+        targetSdkVersion 22
         versionCode 1
         versionName '0.0.1'
     }
 }
-
-apply plugin: 'android-unit-test'
 
 dependencies {
     repositories {
         mavenCentral()
     }
 
-    compile 'com.android.support:support-v4:20.0.0'
-    testCompile 'com.android.support:support-v4:20.0.0'
-    testCompile 'junit:junit:4.11'
-    testCompile 'org.robolectric:robolectric:2.4'
-    testCompile 'com.squareup:fest-android:1.0.+'
+    // Espresso
+    androidTestCompile('com.android.support.test.espresso:espresso-core:2.0')
+    androidTestCompile('com.android.support.test:testing-support-lib:0.1')
+    // Robolectric
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-core:1.3'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testCompile 'org.hamcrest:hamcrest-integration:1.3'
+    testCompile('org.robolectric:robolectric:2.+') {
+        exclude module: 'classworlds'
+        exclude module: 'commons-logging'
+        exclude module: 'httpclient'
+        exclude module: 'maven-artifact'
+        exclude module: 'maven-artifact-manager'
+        exclude module: 'maven-error-diagnostics'
+        exclude module: 'maven-model'
+        exclude module: 'maven-project'
+        exclude module: 'maven-settings'
+        exclude module: 'plexus-container-default'
+        exclude module: 'plexus-interpolation'
+        exclude module: 'plexus-utils'
+        exclude module: 'wagon-file'
+        exclude module: 'wagon-http-lightweight'
+        exclude module: 'wagon-provider-api'
+    }
 }
 
 /**
  * JAR
  */
-
 task clearJar(type: Delete) {
     delete 'jar/PiwikAndroidSdk.jar'
 }
@@ -51,7 +55,7 @@ task makeJar(type: Copy) {
     from('build/intermediates/bundles/release/')
     into('jar/')
     include('classes.jar')
-    rename ('classes.jar', 'PiwikAndroidSdk.jar')
+    rename('classes.jar', 'PiwikAndroidSdk.jar')
 }
 
 makeJar.dependsOn(clearJar, build)
@@ -59,8 +63,6 @@ makeJar.dependsOn(clearJar, build)
 /**
  * Coverage
  */
-
-
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 
@@ -80,15 +82,15 @@ task jacocoTestReport(type: JacocoReport, dependsOn: "testDebug") {
         html.enabled = true
     }
     classDirectories = fileTree(
-        dir: './build/intermediates/classes/debug',
-        excludes: ['org/piwik/R*.class',
-                   '**/BuildConfig.class',
-                   '**/*$InjectAdapter.class',
-                   '**/*$ModuleAdapter.class',
-                   '**/*$ViewInjector*.class'
-        ])
+            dir: './build/intermediates/classes/debug',
+            excludes: ['org/piwik/R*.class',
+                       '**/BuildConfig.class',
+                       '**/*$InjectAdapter.class',
+                       '**/*$ModuleAdapter.class',
+                       '**/*$ViewInjector*.class'
+            ])
     sourceDirectories = files([
-        'src/main/java',
+            'src/main/java',
     ])
     executionData = files('build/jacoco/testDebug.exec')
 }
@@ -101,18 +103,20 @@ coveralls {
 /**
  * Javadoc
  */
-
-
 android.libraryVariants.all { variant ->
     task("generate${variant.name.capitalize()}Javadoc", type: Javadoc) {
-        description "Generates Javadoc for $variant.name."
+        title = "Documentation for Android $android.defaultConfig.versionName b$android.defaultConfig.versionCode"
+        destinationDir = new File("${project.getProjectDir()}/build/docs/javadoc/")
         source = variant.javaCompile.source
-        ext.androidJar = files(plugins.findPlugin("com.android.library").getBootClasspath())
-        classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
-        options.links("http://docs.oracle.com/javase/7/docs/api/")
-        options.linksOffline("http://d.android.com/reference", "${android.sdkDirectory}/docs/reference")
 
-        // exclude generated files
+        ext.androidJar = "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
+        classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
+
+        description "Generates Javadoc for $variant.name."
+
+        options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
+        options.links("http://docs.oracle.com/javase/7/docs/api/");
+        options.links("http://developer.android.com/reference/reference/");
         exclude '**/BuildConfig.java'
         exclude '**/R.java'
     }

--- a/piwik_sdk/src/main/AndroidManifest.xml
+++ b/piwik_sdk/src/main/AndroidManifest.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.piwik.sdk"
-    android:versionCode="20"
-    android:versionName="20.0" >
-
-    <uses-sdk
-        android:minSdkVersion="7"
-        android:targetSdkVersion="20" />
+    package="org.piwik.sdk">
 
 </manifest>


### PR DESCRIPTION
I updated gradle and all plugins so that you can import and build it in Android Studio 1.1 which is the current stable release.
The test command now requires **:piwik_sdk:build** but otherwise it works as previously. Additionally the unit tests can now also be run from within Android Studio.
> $ ./gradlew :piwik_sdk:clean **:piwik_sdk:build** jacocoTestReport generateReleaseJavadoc coveralls --info

The JavaDoc routine was changed to work with the newer gradle version.
And runProguard was removed from the demo app because it is no longer available (was set to false anyways)