### PR TITLE
Changed RANDOM_VALUE parameter "r" to "rand"

### DIFF
--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -965,7 +965,7 @@ public class Tracker implements Dispatchable<Integer> {
 
         VISIT_SCOPE_CUSTOM_VARIABLES("_cvar"),
         SCREEN_SCOPE_CUSTOM_VARIABLES("cvar"),
-        RANDOM_NUMBER("r"),
+        RANDOM_NUMBER("rand"),
         FIRST_VISIT_TIMESTAMP("_idts"),
         PREVIOUS_VISIT_TIMESTAMP("_viewts"),
         TOTAL_NUMBER_OF_VISITS("_idvc"),


### PR DESCRIPTION
As the idea behind the value is just to prevent caching the actual parameter might be irrelevant, but it should still be the same as in the documentation http://developer.piwik.org/api-reference/tracking-api

Or did i miss something?