### PR TITLE
Corrected resolution for API14+

### DIFF
--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 
 
 public class Piwik {
+    public static final String LOGGER_PREFIX = "PIWIK:";
+
     protected final static Object lock = new Object();
 
     private static HashMap<Application, Piwik> applications = new HashMap<Application, Piwik>();

--- a/piwik_sdk/src/main/java/org/piwik/sdk/tools/DeviceHelper.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/tools/DeviceHelper.java
@@ -1,0 +1,70 @@
+/*
+ * Android SDK for Piwik
+ *
+ * @link https://github.com/piwik/piwik-android-sdk
+ * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ */
+package org.piwik.sdk.tools;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.util.Log;
+import android.view.Display;
+import android.view.WindowManager;
+
+import org.piwik.sdk.Piwik;
+
+import java.lang.reflect.Method;
+
+/**
+ * Helper class to gain information about the device we are running on
+ */
+public class DeviceHelper {
+    private static final String LOGGER_TAG = Piwik.LOGGER_PREFIX + "DeviceHelper";
+
+    /**
+     * Tries to get the most accurate device resolution.
+     * On devices below API17 resolution might not account for statusbar/softkeys.
+     *
+     * @param context your application context
+     * @return [width, height]
+     */
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    public static int[] getResolution(Context context) {
+        int width = -1, height = -1;
+
+        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        Display display = wm.getDefaultDisplay();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            // Recommended way to get the resolution but only available since API17
+            DisplayMetrics dm = new DisplayMetrics();
+            display.getRealMetrics(dm);
+            width = dm.widthPixels;
+            height = dm.heightPixels;
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            // Reflection bad, still this is the best way to get an accurate screen size on API14-16.
+            try {
+                Method getRawWidth = Display.class.getMethod("getRawWidth");
+                Method getRawHeight = Display.class.getMethod("getRawHeight");
+                width = (int) getRawWidth.invoke(display);
+                height = (int) getRawHeight.invoke(display);
+            } catch (Exception e) {
+                Log.w(LOGGER_TAG, "Reflection of getRawWidth/getRawHeight failed on API14-16 unexpectedly.");
+            }
+        }
+
+        if (width == -1 || height == -1) {
+            // This is not accurate on all 4.2+ devices, usually the height is wrong due to statusbar/softkeys
+            // Better than nothing though.
+            DisplayMetrics dm = new DisplayMetrics();
+            display.getMetrics(dm);
+            width = dm.widthPixels;
+            height = dm.heightPixels;
+        }
+
+        return new int[]{width, height};
+    }
+}

--- a/piwik_sdk/src/main/java/org/piwik/sdk/tools/DeviceHelper.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/tools/DeviceHelper.java
@@ -35,8 +35,14 @@ public class DeviceHelper {
     public static int[] getResolution(Context context) {
         int width = -1, height = -1;
 
-        WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
-        Display display = wm.getDefaultDisplay();
+        Display display;
+        try {
+            WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+            display = wm.getDefaultDisplay();
+        } catch (NullPointerException e) {
+            Log.e(LOGGER_TAG, "Window service was not available from this context");
+            return null;
+        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             // Recommended way to get the resolution but only available since API17


### PR DESCRIPTION
The previous getResolution() implementation did not always yield correct results, the new solution gives the correct values for API14+. 

AFAIK there is no 100% solution for <API14 devices just via Context accessor without significant overhead.

Noticed it while testing on my Nexus5@5.1, reported was "1080x1776" actual resolution is "1080x1920".
The correct approach for this is only available since API17, for API14-16 we can trick a bit with reflection and if that fails (i.e.<API14), then we use the previous method.
