### PR TITLE
Autobinder refactoring

### DIFF
--- a/demo_app/src/main/java/com/piwik/demo/SettingsActivity.java
+++ b/demo_app/src/main/java/com/piwik/demo/SettingsActivity.java
@@ -17,6 +17,7 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
 import org.piwik.sdk.PiwikApplication;
+import org.piwik.sdk.QuickTrack;
 
 
 public class SettingsActivity extends Activity {
@@ -27,7 +28,7 @@ public class SettingsActivity extends Activity {
         button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                ((PiwikApplication) getApplication()).getTracker().activityStart(settingsActivity);
+                QuickTrack.track((PiwikApplication) getApplication(),settingsActivity);
             }
         });
 

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -7,13 +7,9 @@
 
 package org.piwik.sdk;
 
-import android.annotation.TargetApi;
-import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
-import android.os.Bundle;
 
 import java.net.MalformedURLException;
 import java.util.HashMap;
@@ -22,7 +18,7 @@ import java.util.HashMap;
 public class Piwik {
     public static final String LOGGER_PREFIX = "PIWIK:";
 
-    protected final static Object lock = new Object();
+    private final static Object lock = new Object();
 
     private static HashMap<Application, Piwik> applications = new HashMap<Application, Piwik>();
 
@@ -36,46 +32,6 @@ public class Piwik {
 
     private Piwik(Application application) {
         this.application = application;
-    }
-
-    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
-    public void autoBindActivities(final Tracker tracker) {
-        this.application.registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
-            @Override
-            public void onActivityCreated(Activity activity, Bundle bundle) {
-
-            }
-
-            @Override
-            public void onActivityStarted(Activity activity) {
-                tracker.activityStart(activity);
-            }
-
-            @Override
-            public void onActivityResumed(Activity activity) {
-                tracker.activityResumed(activity);
-            }
-
-            @Override
-            public void onActivityPaused(Activity activity) {
-                tracker.activityPaused(activity);
-            }
-
-            @Override
-            public void onActivityStopped(Activity activity) {
-                tracker.activityStop(activity);
-            }
-
-            @Override
-            public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
-
-            }
-
-            @Override
-            public void onActivityDestroyed(Activity activity) {
-
-            }
-        });
     }
 
     public static Piwik getInstance(Application application) {

--- a/piwik_sdk/src/main/java/org/piwik/sdk/QuickTrack.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/QuickTrack.java
@@ -1,0 +1,121 @@
+/*
+ * Android SDK for Piwik
+ *
+ * @link https://github.com/piwik/piwik-android-sdk
+ * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ */
+
+package org.piwik.sdk;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.Application;
+import android.os.Build;
+import android.os.Bundle;
+import android.text.TextUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Methods to do tracking easier/quicker
+ */
+public class QuickTrack {
+    /**
+     * This method will bind a tracker to your application,
+     * causing it to automatically track Activities within your app.
+     *
+     * @param app     your app
+     * @param tracker the tracker to use
+     * @return the registered callback, you need this if you wanted to unregister the callback again
+     */
+    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+    public static Application.ActivityLifecycleCallbacks bindToApp(final Application app, final Tracker tracker) {
+        final Application.ActivityLifecycleCallbacks callback = new Application.ActivityLifecycleCallbacks() {
+            @Override
+            public void onActivityCreated(Activity activity, Bundle bundle) {
+
+            }
+
+            @Override
+            public void onActivityStarted(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityResumed(Activity activity) {
+                track(tracker,activity);
+            }
+
+            @Override
+            public void onActivityPaused(Activity activity) {
+
+            }
+
+            @Override
+            public void onActivityStopped(Activity activity) {
+                if (activity != null && activity.isTaskRoot()) {
+                    tracker.dispatch();
+                }
+            }
+
+            @Override
+            public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
+
+            }
+
+            @Override
+            public void onActivityDestroyed(Activity activity) {
+
+            }
+        };
+        app.registerActivityLifecycleCallbacks(callback);
+        return callback;
+    }
+
+    /**
+     * Calls {@link Tracker#trackScreenView(String, String)} for an activity.
+     * Uses the activity-stack as path and activity title as names.
+     * @param piwikApplication
+     * @param activity
+     */
+    public static void track(PiwikApplication piwikApplication, Activity activity) {
+        track(piwikApplication.getTracker(), activity);
+    }
+
+    /**
+     * Calls {@link Tracker#trackScreenView(String, String)} for an activity.
+     * Uses the activity-stack as path and activity title as names.
+     * @param tracker
+     * @param activity
+     */
+    public static void track(Tracker tracker, Activity activity) {
+        if (activity != null) {
+            String breadcrumbs = getBreadcrumbs(activity);
+            tracker.trackScreenView(breadcrumbsToPath(breadcrumbs), breadcrumbs);
+        }
+    }
+
+    private static String getBreadcrumbs(final Activity activity) {
+        Activity currentActivity = activity;
+        ArrayList<String> breadcrumbs = new ArrayList<>();
+
+        while (currentActivity != null) {
+            breadcrumbs.add(currentActivity.getTitle().toString());
+            currentActivity = currentActivity.getParent();
+        }
+        return joinSlash(breadcrumbs);
+    }
+
+    private static String joinSlash(List<String> sequence) {
+        if (sequence != null && sequence.size() > 0) {
+            return TextUtils.join("/", sequence);
+        }
+        return "";
+    }
+
+    private static String breadcrumbsToPath(String breadcrumbs) {
+        return breadcrumbs.replaceAll("\\s", "");
+    }
+
+}

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -7,10 +7,8 @@
 
 package org.piwik.sdk;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.text.TextUtils;
 import android.util.Log;
 
 import org.piwik.sdk.tools.DeviceHelper;
@@ -21,7 +19,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.UUID;
@@ -429,46 +426,6 @@ public class Tracker implements Dispatchable<Integer> {
     }
 
     /**
-     * Set action_name param from activity's title and track view
-     *
-     * @param activity Current Activity instance
-     */
-    public void activityStart(final Activity activity) {
-        if (activity != null) {
-            String breadcrumbs = getBreadcrumbs(activity);
-            trackScreenView(breadcrumbsToPath(breadcrumbs), breadcrumbs);
-        }
-    }
-
-    /**
-     * Force dispatching events if main activity is about to stop
-     *
-     * @param activity Current Activity instance
-     */
-    public void activityStop(final Activity activity) {
-        if (activity != null && activity.isTaskRoot()) {
-            dispatch();
-        }
-    }
-
-    /**
-     * @param activity current activity
-     */
-    public void activityPaused(final Activity activity) {
-        activityStop(activity);
-    }
-
-    /**
-     * Don't need to start auto dispatching
-     * due this will be started when any track event occurred
-     *
-     * @param activity current activity
-     */
-    public void activityResumed(final Activity activity) {
-        activityStart(activity);
-    }
-
-    /**
      * Session handling
      */
     public void setNewSession() {
@@ -828,28 +785,6 @@ public class Tracker implements Dispatchable<Integer> {
 
     private String getCurrentDatetime() {
         return new SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ").format(new Date());
-    }
-
-    private String getBreadcrumbs(final Activity activity) {
-        Activity currentActivity = activity;
-        ArrayList<String> breadcrumbs = new ArrayList<String>();
-
-        while (currentActivity != null) {
-            breadcrumbs.add(currentActivity.getTitle().toString());
-            currentActivity = currentActivity.getParent();
-        }
-        return joinSlash(breadcrumbs);
-    }
-
-    private String joinSlash(List<String> sequence) {
-        if (sequence != null && sequence.size() > 0) {
-            return TextUtils.join("/", sequence);
-        }
-        return "";
-    }
-
-    private String breadcrumbsToPath(String breadcrumbs) {
-        return breadcrumbs.replaceAll("\\s", "");
     }
 
     protected String getQuery() {

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -91,7 +91,7 @@ public class TrackerTest {
         piwik.setAppOptOut(true);
         Tracker tracker = piwik.newTracker(testAPIUrl, 1);
         //auto attach tracking screen view
-        piwik.autoBindActivities(tracker);
+        QuickTrack.bindToApp(app, tracker);
 
         // emulate default trackScreenView
         Robolectric.buildActivity(TestActivity.class).create().start().resume().visible().get();


### PR DESCRIPTION
The autobind method now resides in a new class called "QuickTrack".
I've changed the autobinder calledbacks to force a dispatch on activity stop and otherwise just track a screenview "onResume".
It also returns the callback object (after registering it) so the dev can store the object and potentially unregister the callback again.
I've also moved it's helper functions into this class as they were not used for anything else.
The QuickTrack class could later be expanded with other things to "quickly track" ;).

I did not yet implement dispatch pausing as I'm currently uncertain wether it's the best way to go.

With this PR #24 is now resolved.