### PR TITLE
Exception handling refactoring

### DIFF
--- a/demo_app/src/main/java/com/piwik/demo/DemoActivity.java
+++ b/demo_app/src/main/java/com/piwik/demo/DemoActivity.java
@@ -94,8 +94,7 @@ public class DemoActivity extends ActionBarActivity {
         ((PiwikApplication) getApplication()).getTracker()
                 .setDispatchInterval(5)
                 .trackAppDownload()
-                .setUserId(getUserId())
-                .reportUncaughtExceptions(true);
+                .setUserId(getUserId());
 
         initTrackViewListeners();
     }
@@ -127,7 +126,7 @@ public class DemoActivity extends ActionBarActivity {
         button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                int a = 1 / 0;
+                ((PiwikApplication) getApplication()).getTracker().trackException(new Exception("OnPurposeException"), "Crash button", false);
             }
         });
 
@@ -142,7 +141,7 @@ public class DemoActivity extends ActionBarActivity {
                             ((EditText) findViewById(R.id.goalTextEditView)).getText().toString()
                     );
                 } catch (Exception e) {
-                    ((PiwikApplication) getApplication()).getTracker().trackException("DemoActivity", "wrong revenue", false);
+                    ((PiwikApplication) getApplication()).getTracker().trackException(e, "wrong revenue", false);
                     revenue = 0;
                 }
                 ((PiwikApplication) getApplication()).getTracker().trackGoal(1, revenue);

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -32,8 +32,6 @@ public class Piwik {
 
     private boolean dryRun = false;
 
-    protected final static Thread.UncaughtExceptionHandler defaultUEH = Thread.getDefaultUncaughtExceptionHandler();
-
     private Piwik(Application application) {
         this.application = application;
     }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/PiwikExceptionHandler.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/PiwikExceptionHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Android SDK for Piwik
+ *
+ * @link https://github.com/piwik/piwik-android-sdk
+ * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ */
+
+package org.piwik.sdk;
+
+import android.util.Log;
+
+/**
+ * An exception handler that wraps the existing exception handler and dispatches event to a {@link org.piwik.sdk.Tracker}.
+ * <p/>
+ * Also see documentation for {@link org.piwik.sdk.QuickTrack#trackUncaughtExceptions(Tracker)}
+ */
+public class PiwikExceptionHandler implements Thread.UncaughtExceptionHandler {
+    private final Tracker mTracker;
+    private final Thread.UncaughtExceptionHandler mDefaultExceptionHandler;
+
+    public PiwikExceptionHandler(Tracker tracker) {
+        mTracker = tracker;
+        mDefaultExceptionHandler = Thread.getDefaultUncaughtExceptionHandler();
+    }
+
+    public Tracker getTracker() {
+        return mTracker;
+    }
+
+    /**
+     * This will give you the previous exception handler that is now wrapped.
+     *
+     * @return
+     */
+    public Thread.UncaughtExceptionHandler getDefaultExceptionHandler() {
+        return mDefaultExceptionHandler;
+    }
+
+    @Override
+    public void uncaughtException(Thread thread, Throwable ex) {
+        try {
+            String excInfo = ex.getMessage();
+            getTracker().trackException(ex, excInfo, true);
+            // Immediately dispatch as the app might be dying after rethrowing the exception
+            getTracker().dispatch();
+        } catch (Exception e) {
+            Log.e(Tracker.LOGGER_TAG, "Couldn't track uncaught exception", e);
+        } finally {
+            // re-throw critical exception further to the os (important)
+            if (getDefaultExceptionHandler() != null && getDefaultExceptionHandler() != this) {
+                getDefaultExceptionHandler().uncaughtException(thread, ex);
+            }
+        }
+    }
+}

--- a/piwik_sdk/src/main/java/org/piwik/sdk/QuickTrack.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/QuickTrack.java
@@ -21,6 +21,28 @@ import java.util.List;
  * Methods to do tracking easier/quicker
  */
 public class QuickTrack {
+
+    /**
+     * This will create an exception handler that wraps any existing exception handler.
+     * Exceptions will be caught, tracked, dispatched and then rethrown to the previous exception handler.
+     * <p/>
+     * Be wary of relying on this for complete crash tracking..
+     * Think about how to deal with older app versions still throwing already fixed exceptions.
+     * <p/>
+     * See discussion here: https://github.com/piwik/piwik-sdk-android/issues/28
+     *
+     * @param tracker the tracker that should receive the exception events.
+     * @return returns the new (but already active) exception handler.
+     */
+    public static Thread.UncaughtExceptionHandler trackUncaughtExceptions(Tracker tracker) {
+        if (Thread.getDefaultUncaughtExceptionHandler() instanceof PiwikExceptionHandler) {
+            throw new RuntimeException("Trying to wrap an existing PiwikExceptionHandler.");
+        }
+        Thread.UncaughtExceptionHandler handler = new PiwikExceptionHandler(tracker);
+        Thread.setDefaultUncaughtExceptionHandler(handler);
+        return handler;
+    }
+
     /**
      * This method will bind a tracker to your application,
      * causing it to automatically track Activities within your app.
@@ -44,7 +66,7 @@ public class QuickTrack {
 
             @Override
             public void onActivityResumed(Activity activity) {
-                track(tracker,activity);
+                track(tracker, activity);
             }
 
             @Override
@@ -76,6 +98,7 @@ public class QuickTrack {
     /**
      * Calls {@link Tracker#trackScreenView(String, String)} for an activity.
      * Uses the activity-stack as path and activity title as names.
+     *
      * @param piwikApplication
      * @param activity
      */
@@ -86,6 +109,7 @@ public class QuickTrack {
     /**
      * Calls {@link Tracker#trackScreenView(String, String)} for an activity.
      * Uses the activity-stack as path and activity title as names.
+     *
      * @param tracker
      * @param activity
      */

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -651,7 +651,7 @@ public class Tracker implements Dispatchable<Integer> {
      * <p/>
      * For this to be useful you should ensure that proguard does not remove all classnames and line numbers.
      * Also note that if this is used across different app versions and obfuscation is used, the same exception might be mapped to different obfuscated names by proguard.
-     * This would be the same exception is tracked as different events by Piwik.
+     * This would mean the same exception (event) is tracked as different events by Piwik.
      *
      * @param ex          exception instance
      * @param description exception message

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -111,7 +111,6 @@ public class Tracker implements Dispatchable<Integer> {
         setNewSession();
         setSessionTimeout(piwikDefaultSessionTimeout);
         visitorId = getRandomVisitorId();
-        reportUncaughtExceptions(true);
         this.siteId = siteId;
     }
 
@@ -647,24 +646,6 @@ public class Tracker implements Dispatchable<Integer> {
      * Caught exceptions are errors in your app for which you've defined exception handling code,
      * such as the occasional timeout of a network connection during a request for data.
      *
-     * @param className   $ClassName:$lineNumber
-     * @param description exception message
-     * @param isFatal     true if it's RunTimeException
-     */
-    public void trackException(String className, String description, boolean isFatal) {
-        className = className != null && className.length() > 0 ? className : DEFAULT_UNKNOWN_VALUE;
-        String actionName = "exception/" +
-                (isFatal ? "fatal/" : "") +
-                (className + "/") + description;
-
-        set(QueryParams.ACTION_NAME, actionName);
-        trackEvent("Exception", className, description, isFatal ? 1 : 0);
-    }
-
-    /**
-     * Caught exceptions are errors in your app for which you've defined exception handling code,
-     * such as the occasional timeout of a network connection during a request for data.
-     *
      * @param ex          exception instance
      * @param description exception message
      * @param isFatal     true if it's fatal exeption
@@ -678,51 +659,10 @@ public class Tracker implements Dispatchable<Integer> {
             Log.w(Tracker.LOGGER_TAG, "Couldn't get stack info", e);
             className = ex.getClass().getName();
         }
-
-        trackException(className, description, isFatal);
+        String actionName = "exception/" + (isFatal ? "fatal/" : "") + (className + "/") + description;
+        set(QueryParams.ACTION_NAME, actionName);
+        trackEvent("Exception", className, description, isFatal ? 1 : 0);
     }
-
-    protected final Thread.UncaughtExceptionHandler customUEH =
-            new Thread.UncaughtExceptionHandler() {
-
-                @Override
-                public void uncaughtException(Thread thread, Throwable ex) {
-                    try {
-                        String excInfo = ex.getMessage();
-
-                        // track
-                        trackException(ex, excInfo, true);
-
-                        // dispatch immediately
-                        dispatch();
-                    } catch (Exception e) {
-                        // fail silently
-                        Log.e(Tracker.LOGGER_TAG, "Couldn't track uncaught exception", e);
-                    } finally {
-                        // re-throw critical exception further to the os (important)
-                        if (Piwik.defaultUEH != null && Piwik.defaultUEH != customUEH) {
-                            Piwik.defaultUEH.uncaughtException(thread, ex);
-                        }
-                    }
-
-                }
-            };
-
-    /**
-     * Uncaught exceptions are sent to Piwik automatically by default
-     *
-     * @param toggle true if reporting should be enabled
-     */
-    public Tracker reportUncaughtExceptions(boolean toggle) {
-        if (toggle) {
-            // Setup handler for uncaught exception
-            Thread.setDefaultUncaughtExceptionHandler(customUEH);
-        } else {
-            Thread.setDefaultUncaughtExceptionHandler(Piwik.defaultUEH);
-        }
-        return this;
-    }
-
 
     /**
      * Set up required params

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -645,10 +645,17 @@ public class Tracker implements Dispatchable<Integer> {
     /**
      * Caught exceptions are errors in your app for which you've defined exception handling code,
      * such as the occasional timeout of a network connection during a request for data.
+     * <p/>
+     * This is just a different way to define an event.
+     * Keep in mind Piwik is not a crash tracker, use this sparingly.
+     * <p/>
+     * For this to be useful you should ensure that proguard does not remove all classnames and line numbers.
+     * Also note that if this is used across different app versions and obfuscation is used, the same exception might be mapped to different obfuscated names by proguard.
+     * This would be the same exception is tracked as different events by Piwik.
      *
      * @param ex          exception instance
      * @param description exception message
-     * @param isFatal     true if it's fatal exeption
+     * @param isFatal     true if it's fatal exception
      */
     public void trackException(Throwable ex, String description, boolean isFatal) {
         String className;

--- a/piwik_sdk/src/test/java/org/piwik/sdk/QuickTrackTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/QuickTrackTest.java
@@ -1,0 +1,113 @@
+/*
+ * Android SDK for Piwik
+ *
+ * @link https://github.com/piwik/piwik-android-sdk
+ * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ */
+
+package org.piwik.sdk;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+
+@Config(emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class QuickTrackTest {
+    static Tracker dummyTracker;
+    static Piwik dummyPiwik;
+    static TestPiwikApplication dummyApp;
+    final static String testAPIUrl = "http://example.com";
+
+    @BeforeClass
+    public static void initDummyTracker() throws Exception {
+        dummyApp = new TestPiwikApplication();
+        dummyPiwik = Piwik.getInstance(dummyApp);
+        dummyTracker = createNewTracker();
+    }
+
+    private static Tracker createNewTracker() throws MalformedURLException {
+        return dummyPiwik.newTracker(testAPIUrl, 1);
+    }
+
+    @Before
+    public void clearTracker() throws Exception {
+        dummyApp.clearSharedPreferences();
+        dummyPiwik.setDryRun(true);
+        dummyPiwik.setAppOptOut(true);
+        dummyTracker.afterTracking();
+        dummyTracker.clearLastEvent();
+        dummyTracker.setAPIUrl(testAPIUrl);
+        dummyTracker.setApplicationDomain(null);
+    }
+
+    private static class QueryHashMap<String, V> extends HashMap<String, V> {
+
+        private QueryHashMap() {
+            super(10);
+        }
+
+        public V get(QueryParams key) {
+            return get(key.toString());
+        }
+    }
+
+    private static QueryHashMap<String, String> parseEventUrl(String url) throws Exception {
+        QueryHashMap<String, String> values = new QueryHashMap<String, String>();
+
+        List<NameValuePair> params = URLEncodedUtils.parse(new URI("http://localhost/" + url), "UTF-8");
+
+        for (NameValuePair param : params) {
+            values.put(param.getName(), param.getValue());
+        }
+
+        return values;
+    }
+
+    private static void validateDefaultQuery(QueryHashMap<String, String> params) {
+        assertEquals(params.get(QueryParams.SITE_ID), "1");
+        assertEquals(params.get(QueryParams.RECORD), "1");
+        assertEquals(params.get(QueryParams.SEND_IMAGE), "0");
+        assertEquals(params.get(QueryParams.VISITOR_ID).length(), 16);
+        assertEquals(params.get(QueryParams.LANGUAGE), "en");
+        assertTrue(params.get(QueryParams.URL_PATH).startsWith("http://"));
+        assertTrue(Integer.parseInt(params.get(QueryParams.RANDOM_NUMBER)) > 0);
+    }
+
+    @Test
+    public void testPiwikExceptionHandler() throws Exception {
+        assertFalse(Thread.getDefaultUncaughtExceptionHandler() instanceof PiwikExceptionHandler);
+        QuickTrack.trackUncaughtExceptions(dummyTracker);
+        assertTrue(Thread.getDefaultUncaughtExceptionHandler() instanceof PiwikExceptionHandler);
+        try {
+            int i = 1 / 0;
+            assertNotEquals(i, 0);
+        } catch (Exception e) {
+            (Thread.getDefaultUncaughtExceptionHandler()).uncaughtException(Thread.currentThread(), e);
+        }
+        QueryHashMap<String, String> queryParams = parseEventUrl(dummyTracker.getLastEvent());
+        validateDefaultQuery(queryParams);
+        assertEquals(queryParams.get(QueryParams.EVENT_CATEGORY), "Exception");
+        assertTrue(queryParams.get(QueryParams.EVENT_ACTION)
+                .startsWith("org.piwik.sdk.QuickTrackTest/testPiwikExceptionHandler:"));
+        assertEquals(queryParams.get(QueryParams.EVENT_NAME), "/ by zero");
+        assertEquals(queryParams.get(QueryParams.EVENT_VALUE), "1");
+    }
+
+}

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -447,34 +447,21 @@ public class TrackerTest {
 
     @Test
     public void testTrackException() throws Exception {
-        dummyTracker.trackException("ClassName:10+2 2", "<Null> exception", false);
+        Exception catchedException;
+        try {
+            throw new Exception("Test");
+        } catch (Exception e) {
+            catchedException = e;
+        }
+        assertNotNull(catchedException);
+        dummyTracker.trackException(catchedException, "<Null> exception", false);
         QueryHashMap<String, String> queryParams = parseEventUrl(dummyTracker.getLastEvent());
-
         assertEquals(queryParams.get(QueryParams.EVENT_CATEGORY), "Exception");
-        assertEquals(queryParams.get(QueryParams.EVENT_ACTION), "ClassName:10+2 2");
+        StackTraceElement traceElement = catchedException.getStackTrace()[0];
+        assertNotNull(traceElement);
+        assertEquals(queryParams.get(QueryParams.EVENT_ACTION), "org.piwik.sdk.TrackerTest" + "/" + "testTrackException" + ":" + traceElement.getLineNumber());
         assertEquals(queryParams.get(QueryParams.EVENT_NAME), "<Null> exception");
         validateDefaultQuery(queryParams);
-    }
-
-    @Test
-    public void testTrackUncaughtExceptionHandler() throws Exception {
-
-        try {
-            //noinspection NumericOverflow
-            int i = 1 / 0;
-            assertNotEquals(i, 0);
-        } catch (Exception e) {
-            dummyTracker.customUEH.uncaughtException(Thread.currentThread(), e);
-        }
-
-        QueryHashMap<String, String> queryParams = parseEventUrl(dummyTracker.getLastEvent());
-
-        validateDefaultQuery(queryParams);
-        assertEquals(queryParams.get(QueryParams.EVENT_CATEGORY), "Exception");
-        assertTrue(queryParams.get(QueryParams.EVENT_ACTION)
-                .startsWith("org.piwik.sdk.TrackerTest/testTrackUncaughtExceptionHandler"));
-        assertEquals(queryParams.get(QueryParams.EVENT_NAME), "/ by zero");
-        assertEquals(queryParams.get(QueryParams.EVENT_VALUE), "1");
     }
 
     @Test


### PR DESCRIPTION
I've removed the uncaught exception handler due to concerns described in #28.
I've also removed the trackException method that took arbitrary strings as arguments to discourage overusing this or abusing it. In most cases we really want to track a normal event, exceptions are not replacement for if-clauses.

We are left with a trackException method that requires a throwable object. "Custom Exception" are still very much possible just create your own Exception or use a default Exception that takes arguments in the constructor.

I also updated the documentation for the method to point out that Piwik is not a crash tracker. Additionally i mentioned possibly pitfalls from proguard interferring with event matching due to obfuscated classnames or missing linenumbers.

I also contemplated whether the trackException method is really just another helper and should be moved into the new "QuickTrack" class, it's basically a wrapper, exception it just a name for an event.
This would be in contrast to i.e. downloads which are separately tracked on Piwiks UI.

Tracker: Methods for things that are distinct within Piwik UI.
QuickTrack: Methods for things that translate stuff into generic events in the Piwik UI.

This PR doesn't move it though yet, what do you think @dotsbb ?