### PR TITLE
Refactoring for #23 and more

### DIFF
--- a/piwik_sdk/build.gradle
+++ b/piwik_sdk/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     repositories {
         mavenCentral()
     }
-
+    compile 'com.android.support:support-annotations:21.0.0'
     // Espresso
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.0')
     androidTestCompile('com.android.support.test:testing-support-lib:0.1')

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -18,8 +18,6 @@ import java.util.HashMap;
 public class Piwik {
     public static final String LOGGER_PREFIX = "PIWIK:";
 
-    private final static Object lock = new Object();
-
     private static HashMap<Application, Piwik> applications = new HashMap<Application, Piwik>();
 
     private Application application;
@@ -34,16 +32,14 @@ public class Piwik {
         this.application = application;
     }
 
-    public static Piwik getInstance(Application application) {
-        synchronized (lock) {
-            Piwik piwik = applications.get(application);
-            if (piwik != null) {
-                return piwik;
-            }
-            piwik = new Piwik(application);
-            applications.put(application, piwik);
+    public static synchronized Piwik getInstance(Application application) {
+        Piwik piwik = applications.get(application);
+        if (piwik != null) {
             return piwik;
         }
+        piwik = new Piwik(application);
+        applications.put(application, piwik);
+        return piwik;
     }
 
     /**

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -38,14 +38,12 @@ public class Piwik {
     }
 
     /**
-     * @deprecated
-     * Use {@link #newTracker(String, int)} as there are security concerns over the authToken.
-     *
      * @param trackerUrl (required) Tracking HTTP API endpoint, for example, http://your-piwik-domain.tld/piwik.php
      * @param siteId     (required) id of site
      * @param authToken  (optional) could be null or valid auth token.
      * @return Tracker object
      * @throws MalformedURLException
+     * @deprecated Use {@link #newTracker(String, int)} as there are security concerns over the authToken.
      */
     @Deprecated
     public Tracker newTracker(String trackerUrl, int siteId, String authToken) throws MalformedURLException {
@@ -78,6 +76,7 @@ public class Piwik {
      * The dryRun flag set to true prevents any data from being sent to Piwik.
      * The dryRun flag should be set whenever you are testing or debugging an implementation and do not want
      * test data to appear in your Piwik reports. To set the dry run flag, use:
+     *
      * @param dryRun true if you don't want to send any data to piwik
      */
     public void setDryRun(boolean dryRun) {
@@ -90,7 +89,7 @@ public class Piwik {
 
     protected SharedPreferences getSharedPreferences(Tracker tracker) {
         String preferenceName = tracker.getAPIUrl().toString();
-        preferenceName = preferenceName.replace("https://","").replace("http://","").replace("/","_");
-        return getContext().getSharedPreferences(preferenceName, Context.MODE_PRIVATE);
+        preferenceName = preferenceName.replace("https://", "").replace("http://", "").replace("/", "_");
+        return getContext().getSharedPreferences(preferenceName + "id" + tracker.getSiteId(), Context.MODE_PRIVATE);
     }
 }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -15,6 +15,7 @@ import java.net.MalformedURLException;
 
 public class Piwik {
     public static final String LOGGER_PREFIX = "PIWIK:";
+    public static final String PREFERENCE_FILE_NAME = "org.piwik.sdk";
     private final Context mContext;
     private boolean mOptOut = false;
     private boolean mDryRun = false;
@@ -87,9 +88,7 @@ public class Piwik {
         return getContext().getPackageName();
     }
 
-    protected SharedPreferences getSharedPreferences(Tracker tracker) {
-        String preferenceName = tracker.getAPIUrl().toString();
-        preferenceName = preferenceName.replace("https://", "").replace("http://", "").replace("/", "_");
-        return getContext().getSharedPreferences(preferenceName + "id" + tracker.getSiteId(), Context.MODE_PRIVATE);
+    protected SharedPreferences getSharedPreferences() {
+        return getContext().getSharedPreferences(PREFERENCE_FILE_NAME, Context.MODE_PRIVATE);
     }
 }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -7,89 +7,91 @@
 
 package org.piwik.sdk;
 
-import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 
 import java.net.MalformedURLException;
-import java.util.HashMap;
 
 
 public class Piwik {
     public static final String LOGGER_PREFIX = "PIWIK:";
-
-    private static HashMap<Application, Piwik> applications = new HashMap<Application, Piwik>();
-
-    private Application application;
-
-    private boolean optOut = false;
-
-    private boolean dryRun = false;
+    private final Context mContext;
+    private boolean mOptOut = false;
+    private boolean mDryRun = false;
 
     protected final static Thread.UncaughtExceptionHandler defaultUEH = Thread.getDefaultUncaughtExceptionHandler();
 
-    private Piwik(Application application) {
-        this.application = application;
+    private static Piwik sInstance;
+
+    public static synchronized Piwik getInstance(Context context) {
+        if (sInstance == null)
+            sInstance = new Piwik(context);
+        return sInstance;
     }
 
-    public static synchronized Piwik getInstance(Application application) {
-        Piwik piwik = applications.get(application);
-        if (piwik != null) {
-            return piwik;
-        }
-        piwik = new Piwik(application);
-        applications.put(application, piwik);
-        return piwik;
+    private Piwik(Context context) {
+        mContext = context.getApplicationContext();
+    }
+
+    protected Context getContext() {
+        return mContext;
+    }
+
+    /**
+     * @deprecated
+     * Use {@link #newTracker(String, int)} as there are security concerns over the authToken.
+     *
+     * @param trackerUrl (required) Tracking HTTP API endpoint, for example, http://your-piwik-domain.tld/piwik.php
+     * @param siteId     (required) id of site
+     * @param authToken  (optional) could be null or valid auth token.
+     * @return Tracker object
+     * @throws MalformedURLException
+     */
+    @Deprecated
+    public Tracker newTracker(String trackerUrl, int siteId, String authToken) throws MalformedURLException {
+        return new Tracker(trackerUrl, siteId, authToken, this);
     }
 
     /**
      * @param trackerUrl (required) Tracking HTTP API endpoint, for example, http://your-piwik-domain.tld/piwik.php
      * @param siteId     (required) id of site
-     * @param authToken  (optional) could be null or valid auth token. @deprecated since Piwik 2.8.
-     *
      * @return Tracker object
      * @throws MalformedURLException
      */
-    public Tracker newTracker(String trackerUrl, int siteId, String authToken) throws MalformedURLException {
-        return new Tracker(trackerUrl, siteId, authToken, this);
-    }
-
     public Tracker newTracker(String trackerUrl, int siteId) throws MalformedURLException {
         return new Tracker(trackerUrl, siteId, null, this);
     }
 
     public void setAppOptOut(boolean optOut) {
-        this.optOut = optOut;
+        mOptOut = optOut;
     }
 
     public boolean isOptOut() {
-        return optOut;
+        return mOptOut;
     }
 
     public boolean isDryRun() {
-        return dryRun;
+        return mDryRun;
     }
 
     /**
      * The dryRun flag set to true prevents any data from being sent to Piwik.
      * The dryRun flag should be set whenever you are testing or debugging an implementation and do not want
      * test data to appear in your Piwik reports. To set the dry run flag, use:
-     * <p/>
-     * Piwik.getInstance(this).setDryRun(true);
+     * @param dryRun true if you don't want to send any data to piwik
      */
     public void setDryRun(boolean dryRun) {
-        this.dryRun = dryRun;
+        mDryRun = dryRun;
     }
 
     public String getApplicationDomain() {
-        return application.getPackageName();
+        return getContext().getPackageName();
     }
 
-    public Context getApplicationContext() {
-        return application.getApplicationContext();
-    }
-
-    public SharedPreferences getSharedPreferences(String s, int modePrivate) {
-        return application.getSharedPreferences(s, modePrivate);
+    protected SharedPreferences getSharedPreferences(Tracker tracker) {
+        String preferenceName = tracker.getAPIUrl().toString();
+        preferenceName.replace("//:","_");
+        preferenceName.replace("/","_");
+        return getContext().getSharedPreferences(preferenceName, Context.MODE_PRIVATE);
     }
 }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -90,8 +90,7 @@ public class Piwik {
 
     protected SharedPreferences getSharedPreferences(Tracker tracker) {
         String preferenceName = tracker.getAPIUrl().toString();
-        preferenceName.replace("//:","_");
-        preferenceName.replace("/","_");
+        preferenceName = preferenceName.replace("https://","").replace("http://","").replace("/","_");
         return getContext().getSharedPreferences(preferenceName, Context.MODE_PRIVATE);
     }
 }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -7,7 +7,6 @@
 
 package org.piwik.sdk;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
 
@@ -51,7 +50,7 @@ public class Tracker implements Dispatchable<Integer> {
     /**
      * Tracking HTTP API endpoint, for example, http://your-piwik-domain.tld/piwik.php
      */
-    private URL apiUrl;
+    private URL mApiUrl;
 
     /**
      * Defines the User ID for this request.
@@ -140,7 +139,7 @@ public class Tracker implements Dispatchable<Integer> {
 
             TrackerBulkURLProcessor worker =
                     new TrackerBulkURLProcessor(this, piwikHTTPRequestTimeout, piwik.isDryRun());
-            worker.processBulkURLs(apiUrl, events, authToken);
+            worker.processBulkURLs(mApiUrl, events, authToken);
 
             return true;
         }
@@ -329,7 +328,7 @@ public class Tracker implements Dispatchable<Integer> {
             return queryParams.get(QueryParams.SCREEN_RESOLUTION.toString());
         } else {
             if (mScreenResolution == null) {
-                int[] resolution = DeviceHelper.getResolution(piwik.getApplicationContext());
+                int[] resolution = DeviceHelper.getResolution(piwik.getContext());
                 if (resolution != null) {
                     mScreenResolution = formatResolution(resolution[0], resolution[1]);
                 } else {
@@ -545,8 +544,7 @@ public class Tracker implements Dispatchable<Integer> {
      * by using SharedPreferences as flag storage
      */
     public Tracker trackAppDownload() {
-        SharedPreferences prefs = piwik.getSharedPreferences(
-                Piwik.class.getPackage().getName(), Context.MODE_PRIVATE);
+        SharedPreferences prefs = piwik.getSharedPreferences(this);
 
         if (!prefs.getBoolean("downloaded", false)) {
             SharedPreferences.Editor editor = prefs.edit();
@@ -848,17 +846,17 @@ public class Tracker implements Dispatchable<Integer> {
         String path = url.getPath();
 
         if (path.endsWith("piwik.php") || path.endsWith("piwik-proxy.php")) {
-            this.apiUrl = url;
+            this.mApiUrl = url;
         } else {
             if (!path.endsWith("/")) {
                 path += "/";
             }
-            this.apiUrl = new URL(url, path + "piwik.php");
+            this.mApiUrl = new URL(url, path + "piwik.php");
         }
     }
 
-    protected String getAPIUrl() {
-        return apiUrl.toString();
+    protected URL getAPIUrl() {
+        return mApiUrl;
     }
 
     private String getRandomVisitorId() {
@@ -872,13 +870,13 @@ public class Tracker implements Dispatchable<Integer> {
 
         Tracker tracker = (Tracker) o;
 
-        return siteId == tracker.siteId && apiUrl.equals(tracker.apiUrl);
+        return siteId == tracker.siteId && mApiUrl.equals(tracker.mApiUrl);
     }
 
     @Override
     public int hashCode() {
         int result = siteId;
-        result = 31 * result + apiUrl.hashCode();
+        result = 31 * result + mApiUrl.hashCode();
         return result;
     }
 

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -863,6 +863,10 @@ public class Tracker implements Dispatchable<Integer> {
         return UUID.randomUUID().toString().replaceAll("-", "").substring(0, 16);
     }
 
+    public SharedPreferences getSharedPreferences() {
+        return piwik.getSharedPreferences(this);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -8,6 +8,7 @@
 package org.piwik.sdk;
 
 import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import org.piwik.sdk.tools.DeviceHelper;
@@ -45,12 +46,12 @@ public class Tracker implements Dispatchable<Integer> {
     /**
      * The ID of the website we're tracking a visit/action for.
      */
-    private int siteId;
+    private final int mSiteId;
 
     /**
      * Tracking HTTP API endpoint, for example, http://your-piwik-domain.tld/piwik.php
      */
-    private URL mApiUrl;
+    private final URL mApiUrl;
 
     /**
      * Defines the User ID for this request.
@@ -63,24 +64,25 @@ public class Tracker implements Dispatchable<Integer> {
      * If a visit is found in the last 30 minutes with your specified User ID,
      * then the new action will be recorded to this existing visit.
      */
-    private String userId;
+    private String mUserId;
 
     /**
      * The unique visitor ID, must be a 16 characters hexadecimal string.
      * Every unique visitor must be assigned a different ID and this ID must not change after it is assigned.
      * If this value is not set Piwik will still track visits, but the unique visitors metric might be less accurate.
      */
-    private String visitorId;
+    private String mVisitorId;
 
     /**
      * 32 character authorization key used to authenticate the API request.
      * Should be equals `token_auth` value of the Super User
      * or a user with admin access to the website visits are being tracked for.
      */
-    private String authToken;
+    private final String mAuthToken;
 
 
-    private Piwik piwik;
+    private final Piwik mPiwik;
+
     private String lastEvent;
     private boolean isDispatching = false;
     private int dispatchInterval = piwikDefaultDispatchTimer;
@@ -102,15 +104,6 @@ public class Tracker implements Dispatchable<Integer> {
     private final Random randomObject = new Random(new Date().getTime());
 
 
-    private Tracker(String url, int siteId) throws MalformedURLException {
-        setAPIUrl(url);
-        setNewSession();
-        setSessionTimeout(piwikDefaultSessionTimeout);
-        visitorId = getRandomVisitorId();
-        reportUncaughtExceptions(true);
-        this.siteId = siteId;
-    }
-
     /**
      * Use Piwik.newTracker() method to create new trackers
      *
@@ -120,10 +113,34 @@ public class Tracker implements Dispatchable<Integer> {
      * @param piwik     piwik object used to gain access to application params such as name, resolution or lang
      * @throws MalformedURLException
      */
-    protected Tracker(String url, int siteId, String authToken, Piwik piwik) throws MalformedURLException {
-        this(url, siteId);
-        this.authToken = authToken;
-        this.piwik = piwik;
+    protected Tracker(@NonNull final String url, int siteId, String authToken, @NonNull Piwik piwik) throws MalformedURLException {
+        if (url == null)
+            throw new MalformedURLException("You must provide the Piwik Tracker URL! e.g. http://piwik.website.org/piwik.php");
+
+        String checkUrl = url;
+        if (checkUrl.endsWith("piwik.php") || checkUrl.endsWith("piwik-proxy.php")) {
+            mApiUrl = new URL(checkUrl);
+        } else {
+            if (!checkUrl.endsWith("/")) {
+                checkUrl += "/";
+            }
+            mApiUrl = new URL(checkUrl + "piwik.php");
+        }
+        mSiteId = siteId;
+
+        setNewSession();
+        setSessionTimeout(piwikDefaultSessionTimeout);
+        reportUncaughtExceptions(true);
+        mAuthToken = authToken;
+        mPiwik = piwik;
+    }
+
+    protected URL getAPIUrl() {
+        return mApiUrl;
+    }
+
+    protected int getSiteId() {
+        return mSiteId;
     }
 
     /**
@@ -132,14 +149,14 @@ public class Tracker implements Dispatchable<Integer> {
      * @return true if there are any queued events and opt out is inactive
      */
     public boolean dispatch() {
-        if (!piwik.isOptOut() && queue.size() > 0) {
+        if (!mPiwik.isOptOut() && queue.size() > 0) {
 
             ArrayList<String> events = new ArrayList<String>(queue);
             queue.clear();
 
             TrackerBulkURLProcessor worker =
-                    new TrackerBulkURLProcessor(this, piwikHTTPRequestTimeout, piwik.isDryRun());
-            worker.processBulkURLs(mApiUrl, events, authToken);
+                    new TrackerBulkURLProcessor(this, piwikHTTPRequestTimeout, mPiwik.isDryRun());
+            worker.processBulkURLs(mApiUrl, events, mAuthToken);
 
             return true;
         }
@@ -256,7 +273,7 @@ public class Tracker implements Dispatchable<Integer> {
      */
     public Tracker setUserId(String userId) {
         if (userId != null && userId.length() > 0) {
-            this.userId = userId;
+            this.mUserId = userId;
         }
         return this;
     }
@@ -266,13 +283,13 @@ public class Tracker implements Dispatchable<Integer> {
     }
 
     public Tracker clearUserId() {
-        userId = null;
+        mUserId = null;
         return this;
     }
 
     public Tracker setVisitorId(String visitorId) throws IllegalArgumentException {
         if (confirmVisitorIdFormat(visitorId)) {
-            this.visitorId = visitorId;
+            this.mVisitorId = visitorId;
         }
         return this;
     }
@@ -291,6 +308,7 @@ public class Tracker implements Dispatchable<Integer> {
     /**
      * Domain used to build required parameter url (http://developer.piwik.org/api-reference/tracking-api)
      * If domain wasn't set `Application.getPackageName()` method will be used
+     *
      * @param domain your-domain.com
      */
     public Tracker setApplicationDomain(String domain) {
@@ -299,7 +317,7 @@ public class Tracker implements Dispatchable<Integer> {
     }
 
     protected String getApplicationDomain() {
-        return applicationDomain != null ? applicationDomain : piwik.getApplicationDomain();
+        return applicationDomain != null ? applicationDomain : mPiwik.getApplicationDomain();
     }
 
     /**
@@ -328,7 +346,7 @@ public class Tracker implements Dispatchable<Integer> {
             return queryParams.get(QueryParams.SCREEN_RESOLUTION.toString());
         } else {
             if (mScreenResolution == null) {
-                int[] resolution = DeviceHelper.getResolution(piwik.getContext());
+                int[] resolution = DeviceHelper.getResolution(mPiwik.getContext());
                 if (resolution != null) {
                     mScreenResolution = formatResolution(resolution[0], resolution[1]);
                 } else {
@@ -544,7 +562,7 @@ public class Tracker implements Dispatchable<Integer> {
      * by using SharedPreferences as flag storage
      */
     public Tracker trackAppDownload() {
-        SharedPreferences prefs = piwik.getSharedPreferences(this);
+        SharedPreferences prefs = mPiwik.getSharedPreferences(this);
 
         if (!prefs.getBoolean("downloaded", false)) {
             SharedPreferences.Editor editor = prefs.edit();
@@ -685,7 +703,7 @@ public class Tracker implements Dispatchable<Integer> {
     protected void beforeTracking() {
         set(QueryParams.API_VERSION, defaultAPIVersionValue);
         set(QueryParams.SEND_IMAGE, "0");
-        set(QueryParams.SITE_ID, siteId);
+        set(QueryParams.SITE_ID, mSiteId);
         set(QueryParams.RECORD, defaultRecordValue);
         set(QueryParams.RANDOM_NUMBER, randomObject.nextInt(100000));
         set(QueryParams.SCREEN_RESOLUTION, getResolution());
@@ -693,7 +711,7 @@ public class Tracker implements Dispatchable<Integer> {
         set(QueryParams.USER_AGENT, getUserAgent());
         set(QueryParams.LANGUAGE, getLanguage());
         set(QueryParams.COUNTRY, getCountry());
-        set(QueryParams.VISITOR_ID, visitorId);
+        set(QueryParams.VISITOR_ID, getVisitorId());
         set(QueryParams.USER_ID, getUserId());
         set(QueryParams.DATETIME_OF_REQUEST, getCurrentDatetime());
         set(QueryParams.SCREEN_SCOPE_CUSTOM_VARIABLES, getCustomVariables(QueryParams.SCREEN_SCOPE_CUSTOM_VARIABLES).toString());
@@ -709,7 +727,7 @@ public class Tracker implements Dispatchable<Integer> {
         beforeTracking();
 
         String event = getQuery();
-        if (piwik.isOptOut()) {
+        if (mPiwik.isOptOut()) {
             lastEvent = event;
             Log.d(Tracker.LOGGER_TAG, String.format("URL omitted due to opt out: %s", event));
         } else {
@@ -821,42 +839,13 @@ public class Tracker implements Dispatchable<Integer> {
     }
 
     protected String getUserId() {
-        return userId;
+        return mUserId;
     }
 
     protected String getVisitorId() {
-        return visitorId;
-    }
-
-    /**
-     * Sets the url of the piwik installation the dispatchable will track to.
-     * <p/>
-     * The given string should be in the format of RFC2396. The string will be converted to an url with no other url as
-     * its context.
-     *
-     * @param APIUrl as a string object
-     * @throws MalformedURLException
-     */
-    protected final void setAPIUrl(final String APIUrl) throws MalformedURLException {
-        if (APIUrl == null) {
-            throw new MalformedURLException("You must provide the Piwik Tracker URL! e.g. http://piwik.website.org/piwik.php");
-        }
-
-        URL url = new URL(APIUrl);
-        String path = url.getPath();
-
-        if (path.endsWith("piwik.php") || path.endsWith("piwik-proxy.php")) {
-            this.mApiUrl = url;
-        } else {
-            if (!path.endsWith("/")) {
-                path += "/";
-            }
-            this.mApiUrl = new URL(url, path + "piwik.php");
-        }
-    }
-
-    protected URL getAPIUrl() {
-        return mApiUrl;
+        if(mVisitorId == null)
+            mVisitorId = getRandomVisitorId();
+        return mVisitorId;
     }
 
     private String getRandomVisitorId() {
@@ -864,7 +853,7 @@ public class Tracker implements Dispatchable<Integer> {
     }
 
     public SharedPreferences getSharedPreferences() {
-        return piwik.getSharedPreferences(this);
+        return mPiwik.getSharedPreferences(this);
     }
 
     @Override
@@ -874,12 +863,12 @@ public class Tracker implements Dispatchable<Integer> {
 
         Tracker tracker = (Tracker) o;
 
-        return siteId == tracker.siteId && mApiUrl.equals(tracker.mApiUrl);
+        return mSiteId == tracker.mSiteId && mApiUrl.equals(tracker.mApiUrl);
     }
 
     @Override
     public int hashCode() {
-        int result = siteId;
+        int result = mSiteId;
         result = 31 * result + mApiUrl.hashCode();
         return result;
     }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -562,7 +562,7 @@ public class Tracker implements Dispatchable<Integer> {
      * by using SharedPreferences as flag storage
      */
     public Tracker trackAppDownload() {
-        SharedPreferences prefs = mPiwik.getSharedPreferences(this);
+        SharedPreferences prefs = mPiwik.getSharedPreferences();
 
         if (!prefs.getBoolean("downloaded", false)) {
             SharedPreferences.Editor editor = prefs.edit();
@@ -853,7 +853,7 @@ public class Tracker implements Dispatchable<Integer> {
     }
 
     public SharedPreferences getSharedPreferences() {
-        return mPiwik.getSharedPreferences(this);
+        return mPiwik.getSharedPreferences();
     }
 
     @Override

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TestPiwikApplication.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TestPiwikApplication.java
@@ -5,13 +5,15 @@ import android.content.SharedPreferences;
 import org.robolectric.TestLifecycleApplication;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class TestPiwikApplication extends PiwikApplication implements TestLifecycleApplication {
 
-    HashMap<String, SharedPreferences> prefsHolder;
+    private final List<SharedPreferences> mActivePreferences = new ArrayList<>();
 
     @Override
     public void beforeTest(Method method) {
@@ -31,126 +33,15 @@ public class TestPiwikApplication extends PiwikApplication implements TestLifecy
     }
 
     protected void clearSharedPreferences() {
-        prefsHolder = new HashMap<String, SharedPreferences>();
+        for(SharedPreferences pref : mActivePreferences)
+            pref.edit().clear().commit();
     }
 
     @Override
     public SharedPreferences getSharedPreferences(String namespace, int modePrivate) {
-        SharedPreferences pref = prefsHolder.get(namespace);
-
-        if (pref == null) {
-            pref = new SharedPreferences() {
-                HashMap<String, Boolean> booleanHolder = new HashMap<String, Boolean>();
-
-                @Override
-                public Map<String, ?> getAll() {
-                    return null;
-                }
-
-                @Override
-                public String getString(String s, String s2) {
-                    return null;
-                }
-
-                @Override
-                public Set<String> getStringSet(String s, Set<String> strings) {
-                    return null;
-                }
-
-                @Override
-                public int getInt(String s, int i) {
-                    return 0;
-                }
-
-                @Override
-                public long getLong(String s, long l) {
-                    return 0;
-                }
-
-                @Override
-                public float getFloat(String s, float v) {
-                    return 0;
-                }
-
-                @Override
-                public boolean getBoolean(String s, boolean defaultValue) {
-                    return booleanHolder.containsKey(s) || defaultValue;
-                }
-
-                @Override
-                public boolean contains(String s) {
-                    return false;
-                }
-
-                @Override
-                public Editor edit() {
-                    return new Editor() {
-                        @Override
-                        public Editor putString(String s, String s2) {
-                            return null;
-                        }
-
-                        @Override
-                        public Editor putStringSet(String s, Set<String> strings) {
-                            return null;
-                        }
-
-                        @Override
-                        public Editor putInt(String s, int i) {
-                            return null;
-                        }
-
-                        @Override
-                        public Editor putLong(String s, long l) {
-                            return null;
-                        }
-
-                        @Override
-                        public Editor putFloat(String s, float v) {
-                            return null;
-                        }
-
-                        @Override
-                        public Editor putBoolean(String s, boolean b) {
-                            booleanHolder.put(s, b);
-                            return this;
-                        }
-
-                        @Override
-                        public Editor remove(String s) {
-                            return null;
-                        }
-
-                        @Override
-                        public Editor clear() {
-                            return null;
-                        }
-
-                        @Override
-                        public boolean commit() {
-                            return true;
-                        }
-
-                        @Override
-                        public void apply() {
-
-                        }
-                    };
-                }
-
-                @Override
-                public void registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener onSharedPreferenceChangeListener) {
-
-                }
-
-                @Override
-                public void unregisterOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener onSharedPreferenceChangeListener) {
-
-                }
-            };
-            prefsHolder.put(namespace, pref);
-        }
-
+        SharedPreferences pref = super.getSharedPreferences(namespace,modePrivate);
+        if(!mActivePreferences.contains(pref))
+            mActivePreferences.add(pref);
         return pref;
     }
 }

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -13,6 +13,7 @@ import org.robolectric.annotation.Config;
 
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -180,21 +181,21 @@ public class TrackerTest {
         assertTrue(queryParams.get(QueryParams.URL_PATH).equals("http://my-domain.com/test/test"));
     }
 
-    @Test(expected=IllegalArgumentException.class) 
+    @Test(expected=IllegalArgumentException.class)
     public void testSetTooShortVistorId() {
         String tooShortVisitorId = "0123456789ab";
         dummyTracker.setVisitorId(tooShortVisitorId);
         assertNotEquals(tooShortVisitorId, dummyTracker.getVisitorId());
     }
 
-    @Test(expected=IllegalArgumentException.class) 
+    @Test(expected=IllegalArgumentException.class)
     public void testSetTooLongVistorId() {
         String tooLongVisitorId = "0123456789abcdefghi";
         dummyTracker.setVisitorId(tooLongVisitorId);
         assertNotEquals(tooLongVisitorId, dummyTracker.getVisitorId());
     }
 
-    @Test(expected=IllegalArgumentException.class) 
+    @Test(expected=IllegalArgumentException.class)
     public void testSetVistorIdWithInvalidCharacters() {
         String invalidCharacterVisitorId = "01234-6789-ghief";
         dummyTracker.setVisitorId(invalidCharacterVisitorId);
@@ -503,11 +504,11 @@ public class TrackerTest {
 
         for (String url : urls) {
             dummyTracker.setAPIUrl(url);
-            assertEquals(dummyTracker.getAPIUrl(), "https://demo.org/piwik/piwik.php");
+            assertEquals(dummyTracker.getAPIUrl().toString(), "https://demo.org/piwik/piwik.php");
         }
 
         dummyTracker.setAPIUrl("http://demo.org/piwik-proxy.php");
-        assertEquals(dummyTracker.getAPIUrl(), "http://demo.org/piwik-proxy.php");
+        assertEquals(dummyTracker.getAPIUrl(), new URL("http://demo.org/piwik-proxy.php"));
     }
 
     @Test
@@ -517,7 +518,7 @@ public class TrackerTest {
         System.setProperty("http.agent", "aUserAgent");
 
         assertEquals(dummyTracker.getUserAgent(), defaultUserAgent);
-        
+
         dummyTracker.setUserAgent(customUserAgent);
         assertEquals(dummyTracker.getUserAgent(), customUserAgent);
 

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -48,9 +48,9 @@ public class TrackerTest {
         dummyApp.clearSharedPreferences();
         dummyPiwik.setDryRun(true);
         dummyPiwik.setAppOptOut(true);
+        dummyTracker = createNewTracker();
         dummyTracker.afterTracking();
         dummyTracker.clearLastEvent();
-        dummyTracker.setAPIUrl(testAPIUrl);
         dummyTracker.setApplicationDomain(null);
     }
 
@@ -494,7 +494,8 @@ public class TrackerTest {
     @Test
     public void testSetAPIUrl() throws Exception {
         try {
-            dummyTracker.setAPIUrl(null);
+            dummyPiwik.newTracker(null, 1);
+            assert false;
         } catch (MalformedURLException e) {
             assertTrue(e.getMessage().contains("provide the Piwik Tracker URL!"));
         }
@@ -506,12 +507,10 @@ public class TrackerTest {
         };
 
         for (String url : urls) {
-            dummyTracker.setAPIUrl(url);
-            assertEquals(dummyTracker.getAPIUrl().toString(), "https://demo.org/piwik/piwik.php");
+            assertEquals(dummyPiwik.newTracker(url, 1).getAPIUrl().toString(), "https://demo.org/piwik/piwik.php");
         }
 
-        dummyTracker.setAPIUrl("http://demo.org/piwik-proxy.php");
-        assertEquals(dummyTracker.getAPIUrl(), new URL("http://demo.org/piwik-proxy.php"));
+        assertEquals(dummyPiwik.newTracker("http://demo.org/piwik-proxy.php", 1).getAPIUrl(), new URL("http://demo.org/piwik-proxy.php"));
     }
 
     @Test
@@ -533,15 +532,22 @@ public class TrackerTest {
     public void testTrackerIndividualSharedPreferences() throws Exception {
         Tracker same1 = dummyPiwik.newTracker("http://demo.org/piwik-proxy.php", 0);
         Tracker same2 = dummyPiwik.newTracker("http://demo.org/piwik-proxy.php", 0);
-        Tracker diff  = dummyPiwik.newTracker("http://example.org/piwik-proxy.php", 1);
+        Tracker diff1  = dummyPiwik.newTracker("http://example.org/piwik-proxy.php", 1);
+        Tracker diff2  = dummyPiwik.newTracker("http://example.org/piwik-proxy.php", 2);
         assertFalse(same1.getSharedPreferences().contains("testkey"));
         assertFalse(same2.getSharedPreferences().contains("testkey"));
-        assertFalse(diff.getSharedPreferences().contains("testkey"));
+        assertFalse(diff1.getSharedPreferences().contains("testkey"));
+        assertFalse(diff2.getSharedPreferences().contains("testkey"));
         same1.getSharedPreferences().edit().putString("testkey","1234").commit();
         assertTrue(same1.getSharedPreferences().contains("testkey"));
         assertTrue(same2.getSharedPreferences().contains("testkey"));
         assertEquals(same1.getSharedPreferences().getString("testkey", "a"), same2.getSharedPreferences().getString("testkey", "b"));
-        assertFalse(diff.getSharedPreferences().contains("testkey"));
+        assertFalse(diff1.getSharedPreferences().contains("testkey"));
+        assertFalse(diff2.getSharedPreferences().contains("testkey"));
+
+        diff1.getSharedPreferences().edit().putString("testkey","5678").commit();
+        assertTrue(diff1.getSharedPreferences().contains("testkey"));
+        assertFalse(diff2.getSharedPreferences().contains("testkey"));
     }
 
 }

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -1,6 +1,8 @@
 package org.piwik.sdk;
 
 import android.app.Application;
+import android.content.SharedPreferences;
+
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.junit.Before;
@@ -10,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowPreferenceManager;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -524,6 +527,21 @@ public class TrackerTest {
 
         dummyTracker.setUserAgent(null);
         assertEquals(dummyTracker.getUserAgent(), defaultUserAgent);
+    }
+
+    @Test
+    public void testTrackerIndividualSharedPreferences() throws Exception {
+        Tracker same1 = dummyPiwik.newTracker("http://demo.org/piwik-proxy.php", 0);
+        Tracker same2 = dummyPiwik.newTracker("http://demo.org/piwik-proxy.php", 0);
+        Tracker diff  = dummyPiwik.newTracker("http://example.org/piwik-proxy.php", 1);
+        assertFalse(same1.getSharedPreferences().contains("testkey"));
+        assertFalse(same2.getSharedPreferences().contains("testkey"));
+        assertFalse(diff.getSharedPreferences().contains("testkey"));
+        same1.getSharedPreferences().edit().putString("testkey","1234").commit();
+        assertTrue(same1.getSharedPreferences().contains("testkey"));
+        assertTrue(same2.getSharedPreferences().contains("testkey"));
+        assertEquals(same1.getSharedPreferences().getString("testkey", "a"), same2.getSharedPreferences().getString("testkey", "b"));
+        assertFalse(diff.getSharedPreferences().contains("testkey"));
     }
 
 }

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -1,7 +1,6 @@
 package org.piwik.sdk;
 
 import android.app.Application;
-import android.content.SharedPreferences;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -12,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowPreferenceManager;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -21,7 +19,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 
 @Config(emulateSdk = 18, manifest = Config.NONE)

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -529,27 +529,4 @@ public class TrackerTest {
         dummyTracker.setUserAgent(null);
         assertEquals(dummyTracker.getUserAgent(), defaultUserAgent);
     }
-
-    @Test
-    public void testTrackerIndividualSharedPreferences() throws Exception {
-        Tracker same1 = dummyPiwik.newTracker("http://demo.org/piwik-proxy.php", 0);
-        Tracker same2 = dummyPiwik.newTracker("http://demo.org/piwik-proxy.php", 0);
-        Tracker diff1  = dummyPiwik.newTracker("http://example.org/piwik-proxy.php", 1);
-        Tracker diff2  = dummyPiwik.newTracker("http://example.org/piwik-proxy.php", 2);
-        assertFalse(same1.getSharedPreferences().contains("testkey"));
-        assertFalse(same2.getSharedPreferences().contains("testkey"));
-        assertFalse(diff1.getSharedPreferences().contains("testkey"));
-        assertFalse(diff2.getSharedPreferences().contains("testkey"));
-        same1.getSharedPreferences().edit().putString("testkey","1234").commit();
-        assertTrue(same1.getSharedPreferences().contains("testkey"));
-        assertTrue(same2.getSharedPreferences().contains("testkey"));
-        assertEquals(same1.getSharedPreferences().getString("testkey", "a"), same2.getSharedPreferences().getString("testkey", "b"));
-        assertFalse(diff1.getSharedPreferences().contains("testkey"));
-        assertFalse(diff2.getSharedPreferences().contains("testkey"));
-
-        diff1.getSharedPreferences().edit().putString("testkey","5678").commit();
-        assertTrue(diff1.getSharedPreferences().contains("testkey"));
-        assertFalse(diff2.getSharedPreferences().contains("testkey"));
-    }
-
 }


### PR DESCRIPTION
* Simplified getInstance synchronization
* Removed the HashMap<Application,Tracker>, see #23
* ~~Each Tracker now has their own preferences based on apiurl+siteid. So in the future we can track one-shot events per different trackers. This might see some further changes when i submit a PR with changes for download tracking. Note: If you would update the library and call trackDownload again, it would send a new event as the old preference file was per piwik instance not per tracker.~~
* api-url and site-id are now final and can only be set when creating the tracker. It was previously already not possible to create a tracker with no api-url, why would you then want to create a tracker with one url and then change it later. This also prevents concurrency issues, what if the api-url/siteid get changed while some other routines are accessing them. TL;DR Enforcing the practice of creating a new Tracker for a new api-url/siteid.
* Updated all tests to fit the changes and fixed sharedpreferences not working correctly for testcases.

Some autoformatting and import optimization was done too and each time i change a specific variable i rename it to **m**Variable. m is for member, while in the end it's personal preference, it's in line with naming in official AOSP classes, i hope no one is annoyed by that.

Tests all pass on my machine and this is the first PR against the new dev branch :+1:

