### PR TITLE
Using the "makeJar" adds gitSHA to the file name

### DIFF
--- a/piwik_sdk/build.gradle
+++ b/piwik_sdk/build.gradle
@@ -1,3 +1,7 @@
+def gitSha() {
+    return 'git rev-parse --short HEAD'.execute().text.trim()
+}
+
 apply plugin: 'com.android.library'
 
 android {
@@ -55,7 +59,7 @@ task makeJar(type: Copy) {
     from('build/intermediates/bundles/release/')
     into('jar/')
     include('classes.jar')
-    rename('classes.jar', 'PiwikAndroidSdk.jar')
+    rename('classes.jar', 'PiwikAndroidSdk-' + gitSha() + '.jar')
 }
 
 makeJar.dependsOn(clearJar, build)


### PR DESCRIPTION
This change allows "makeJar" to create files like "PiwikAndroidSdk-7b8c0e8.jar".

This PR contributes to #31 .

I'm not certain what further steps are necessary @mattab .