### PR TITLE
More detailed download tracking

### DIFF
--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -572,12 +572,16 @@ public class Tracker implements Dispatchable<Integer> {
      * @return this tracker again for chaining
      */
     public Tracker trackAppDownload() {
+        return trackAppDownload(ExtraIdentifier.INSTALLER_PACKAGENAME);
+    }
+
+    public Tracker trackAppDownload(ExtraIdentifier extra) {
         SharedPreferences prefs = mPiwik.getSharedPreferences();
         try {
             PackageInfo pkgInfo = mPiwik.getContext().getPackageManager().getPackageInfo(mPiwik.getContext().getPackageName(), 0);
             String firedKey = "downloaded:" + pkgInfo.packageName + ":" + pkgInfo.versionCode;
             if (!prefs.getBoolean(firedKey, false)) {
-                trackNewAppDownload(mPiwik.getContext(), ExtraIdentifier.INSTALLER_PACKAGENAME);
+                trackNewAppDownload(mPiwik.getContext(), extra);
                 prefs.edit().putBoolean(firedKey, true).commit();
             }
         } catch (PackageManager.NameNotFoundException e) {

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -628,7 +628,7 @@ public class Tracker implements Dispatchable<Integer> {
                 }
             } else if (extra == ExtraIdentifier.INSTALLER_PACKAGENAME) {
                 String installer = packMan.getInstallerPackageName(pkg);
-                if (installer.length() < 200)
+                if (installer != null && installer.length() < 200)
                     extraIdentifier = packMan.getInstallerPackageName(pkg);
             }
             installIdentifier.append("/").append(extraIdentifier == null ? DEFAULT_UNKNOWN_VALUE : extraIdentifier);

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -562,8 +562,7 @@ public class Tracker implements Dispatchable<Integer> {
     }
 
     /**
-     * Ensures that tracking application downloading will be fired only once
-     * by using SharedPreferences as flag storage
+     * Fires a download for this app once per update.
      * The install will be tracked as:<p/>
      * 'http://packageName:versionCode/installerPackagename'
      * <p/>
@@ -572,16 +571,22 @@ public class Tracker implements Dispatchable<Integer> {
      * @return this tracker again for chaining
      */
     public Tracker trackAppDownload() {
-        return trackAppDownload(ExtraIdentifier.INSTALLER_PACKAGENAME);
+        return trackAppDownload(mPiwik.getContext(), ExtraIdentifier.INSTALLER_PACKAGENAME);
     }
 
-    public Tracker trackAppDownload(ExtraIdentifier extra) {
+    /**
+     * Fires a download for an arbitrary app once per update.
+     * @param app the app to track
+     * @param extra {@link org.piwik.sdk.Tracker.ExtraIdentifier#APK_CHECKSUM} or {@link org.piwik.sdk.Tracker.ExtraIdentifier#INSTALLER_PACKAGENAME}
+     * @return this tracker for chaining
+     */
+    public Tracker trackAppDownload(Context app, ExtraIdentifier extra) {
         SharedPreferences prefs = mPiwik.getSharedPreferences();
         try {
-            PackageInfo pkgInfo = mPiwik.getContext().getPackageManager().getPackageInfo(mPiwik.getContext().getPackageName(), 0);
+            PackageInfo pkgInfo = app.getPackageManager().getPackageInfo(app.getPackageName(), 0);
             String firedKey = "downloaded:" + pkgInfo.packageName + ":" + pkgInfo.versionCode;
             if (!prefs.getBoolean(firedKey, false)) {
-                trackNewAppDownload(mPiwik.getContext(), extra);
+                trackNewAppDownload(app, extra);
                 prefs.edit().putBoolean(firedKey, true).commit();
             }
         } catch (PackageManager.NameNotFoundException e) {

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -7,6 +7,7 @@
 
 package org.piwik.sdk;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 import android.content.pm.ApplicationInfo;
@@ -572,10 +573,10 @@ public class Tracker implements Dispatchable<Integer> {
         SharedPreferences prefs = mPiwik.getSharedPreferences();
 
         try {
-            PackageInfo pkgInfo = piwik.getApplicationContext().getPackageManager().getPackageInfo(piwik.getApplicationContext().getPackageName(), 0);
+            PackageInfo pkgInfo = mPiwik.getContext().getPackageManager().getPackageInfo(mPiwik.getContext().getPackageName(), 0);
             String firedKey = "downloaded:" + pkgInfo.packageName + ":" + pkgInfo.versionCode;
             if (!prefs.getBoolean(firedKey, false)) {
-                trackNewAppDownload(piwik.getApplicationContext());
+                trackNewAppDownload(mPiwik.getContext());
                 prefs.edit().putBoolean(firedKey, true).commit();
             }
         } catch (PackageManager.NameNotFoundException e) {

--- a/piwik_sdk/src/main/java/org/piwik/sdk/tools/Checksum.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/tools/Checksum.java
@@ -1,0 +1,72 @@
+/*
+ * Android SDK for Piwik
+ *
+ * @link https://github.com/piwik/piwik-android-sdk
+ * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ */
+
+package org.piwik.sdk.tools;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.MessageDigest;
+
+/**
+ * Offers to calculate checksums
+ */
+public class Checksum {
+    private static final String HEXES = "0123456789ABCDEF";
+
+    /**
+     * Transforms byte into hex representation.
+     *
+     * @param raw
+     * @return
+     */
+    public static String getHex(byte[] raw) {
+        if (raw == null)
+            return null;
+        final StringBuilder hex = new StringBuilder(2 * raw.length);
+        for (final byte b : raw)
+            hex.append(HEXES.charAt((b & 0xF0) >> 4)).append(HEXES.charAt((b & 0x0F)));
+        return hex.toString();
+    }
+
+    /**
+     * MD5-Checksum for a string.
+     *
+     * @param string
+     * @return
+     * @throws Exception
+     */
+    public static String getMD5Checksum(String string) throws Exception {
+        MessageDigest digest = java.security.MessageDigest.getInstance("MD5");
+        digest.update(string.getBytes());
+        byte messageDigest[] = digest.digest();
+        return getHex(messageDigest);
+    }
+
+    /**
+     * MD5-Checksum for a file.
+     *
+     * @param file
+     * @return
+     * @throws Exception
+     */
+    public static String getMD5Checksum(File file) throws Exception {
+        if (!file.isFile())
+            return null;
+        InputStream fis = new FileInputStream(file);
+        byte[] buffer = new byte[1024];
+        MessageDigest complete = MessageDigest.getInstance("MD5");
+        int numRead;
+        do {
+            numRead = fis.read(buffer);
+            if (numRead > 0)
+                complete.update(buffer, 0, numRead);
+        } while (numRead != -1);
+        fis.close();
+        return getHex(complete.digest());
+    }
+}

--- a/piwik_sdk/src/test/java/org/piwik/sdk/FullEnvPackageManager.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/FullEnvPackageManager.java
@@ -1,0 +1,95 @@
+/*
+ * Android SDK for Piwik
+ *
+ * @link https://github.com/piwik/piwik-android-sdk
+ * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ */
+
+package org.piwik.sdk;
+
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInstaller;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.os.UserHandle;
+import android.support.annotation.NonNull;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.res.builder.RobolectricPackageManager;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Because we need to fake things that RobolectricPackageManager does not offer.
+ * Currently:<p/>
+ * {@link org.robolectric.res.builder.RobolectricPackageManager#setInstallerPackageName(String, String)}
+ */
+public class FullEnvPackageManager extends RobolectricPackageManager {
+    private final HashMap<String, String> mInstallerPackageNames = new HashMap<>();
+
+    @Override
+    public Intent getLeanbackLaunchIntentForPackage(String packageName) {
+        return null;
+    }
+
+    @Override
+    public List<ResolveInfo> queryIntentContentProviders(Intent intent, int flags) {
+        return null;
+    }
+
+    @Override
+    public Drawable getActivityBanner(ComponentName activityName) throws NameNotFoundException {
+        return null;
+    }
+
+    @Override
+    public Drawable getActivityBanner(Intent intent) throws NameNotFoundException {
+        return null;
+    }
+
+    @Override
+    public Drawable getApplicationBanner(ApplicationInfo info) {
+        return null;
+    }
+
+    @Override
+    public Drawable getApplicationBanner(String packageName) throws NameNotFoundException {
+        return null;
+    }
+
+    @Override
+    public Drawable getUserBadgedIcon(Drawable icon, UserHandle user) {
+        return null;
+    }
+
+    @Override
+    public Drawable getUserBadgedDrawableForDensity(Drawable drawable, UserHandle user, Rect badgeLocation, int badgeDensity) {
+        return null;
+    }
+
+    @Override
+    public CharSequence getUserBadgedLabel(CharSequence label, UserHandle user) {
+        return null;
+    }
+
+    @Implementation
+    public void setInstallerPackageName(String targetPackage, String installerPackageName) {
+        mInstallerPackageNames.put(targetPackage, installerPackageName);
+    }
+
+    @Implementation
+    public String getInstallerPackageName(String packageName) {
+        return mInstallerPackageNames.get(packageName);
+    }
+
+    @NonNull
+    @Override
+    public PackageInstaller getPackageInstaller() {
+        return null;
+    }
+}

--- a/piwik_sdk/src/test/java/org/piwik/sdk/FullEnvPackageManager.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/FullEnvPackageManager.java
@@ -23,6 +23,7 @@ import org.robolectric.res.builder.RobolectricPackageManager;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Because we need to fake things that RobolectricPackageManager does not offer.
@@ -91,5 +92,9 @@ public class FullEnvPackageManager extends RobolectricPackageManager {
     @Override
     public PackageInstaller getPackageInstaller() {
         return null;
+    }
+
+    public Map<String, String> getInstallerMap() {
+        return mInstallerPackageNames;
     }
 }

--- a/piwik_sdk/src/test/java/org/piwik/sdk/FullEnvTestLifeCycle.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/FullEnvTestLifeCycle.java
@@ -8,10 +8,13 @@
 package org.piwik.sdk;
 
 import android.app.Application;
+import android.content.pm.PackageInfo;
 
 import org.robolectric.AndroidManifest;
 import org.robolectric.DefaultTestLifecycle;
+import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
+import org.robolectric.res.builder.RobolectricPackageManager;
 
 import java.lang.reflect.Method;
 
@@ -22,6 +25,12 @@ public class FullEnvTestLifeCycle extends DefaultTestLifecycle {
 
     @Override
     public Application createApplication(Method method, AndroidManifest appManifest, Config config) {
+        // FIXME If a future version of Robolectric implements "setInstallerPackageName", remove this.
+        RobolectricPackageManager oldManager = Robolectric.packageManager;
+        RobolectricPackageManager newManager = new FullEnvPackageManager();
+        for (PackageInfo pkg : oldManager.getInstalledPackages(0))
+            newManager.addPackage(pkg);
+        Robolectric.packageManager = newManager;
         return new TestPiwikApplication();
     }
 }

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TestPiwikApplication.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TestPiwikApplication.java
@@ -15,6 +15,11 @@ import java.lang.reflect.Method;
 
 public class TestPiwikApplication extends PiwikApplication implements TestLifecycleApplication {
 
+    public static final String INSTALLER_PACKAGENAME = "com.android.vending users can screw with this value !$()=%ÄÖÜ";
+    public static final byte[] FAKE_APK_DATA = "this is an apk, awesome right?".getBytes();
+    public static final String FAKE_APK_DATA_MD5 = "771BD8971508985852AF8F96170C52FB";
+    public static final int VERSION_CODE = 1;
+    public static final String PACKAGENAME = "org.piwik.sdk.test";
     private File mFakeApk;
 
     @Override
@@ -23,15 +28,14 @@ public class TestPiwikApplication extends PiwikApplication implements TestLifecy
         RobolectricPackageManager rpm = (RobolectricPackageManager) Robolectric.application.getPackageManager();
         PackageInfo packageInfo = new PackageInfo();
         packageInfo.packageName = getPackageName();
-        packageInfo.versionCode = 1;
+        packageInfo.versionCode = VERSION_CODE;
 
         ApplicationInfo applicationInfo = new ApplicationInfo();
         mFakeApk = new File(Environment.getExternalStorageDirectory(), "base.apk");
         applicationInfo.sourceDir = mFakeApk.getAbsolutePath();
         try {
             FileOutputStream out = new FileOutputStream(applicationInfo.sourceDir);
-            byte dataToWrite[] = "somedata".getBytes();
-            out.write(dataToWrite);
+            out.write(FAKE_APK_DATA);
             out.close();
         } catch (java.io.IOException e) {
             e.printStackTrace();
@@ -39,6 +43,8 @@ public class TestPiwikApplication extends PiwikApplication implements TestLifecy
 
         packageInfo.applicationInfo = applicationInfo;
         rpm.addPackage(packageInfo);
+
+        rpm.setInstallerPackageName(getPackageName(), INSTALLER_PACKAGENAME);
         super.onCreate();
     }
 
@@ -64,7 +70,7 @@ public class TestPiwikApplication extends PiwikApplication implements TestLifecy
 
     @Override
     public String getPackageName() {
-        return "org.piwik.sdk.test";
+        return PACKAGENAME;
     }
 
     @Override

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -1,6 +1,7 @@
 package org.piwik.sdk;
 
 import android.app.Application;
+import android.content.Context;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -9,6 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
+import org.robolectric.res.builder.RobolectricPackageManager;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -435,6 +437,19 @@ public class TrackerTest {
         assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
         assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
         assertEquals(TestPiwikApplication.INSTALLER_PACKAGENAME, m.group(3));
+
+        tracker.clearLastEvent();
+
+        FullEnvPackageManager pm = (FullEnvPackageManager) Robolectric.packageManager;
+        pm.getInstallerMap().clear();
+        tracker.trackNewAppDownload(Robolectric.application, Tracker.ExtraIdentifier.INSTALLER_PACKAGENAME);
+        queryParams = parseEventUrl(tracker.getLastEvent());
+        checkNewAppDownload(queryParams);
+        m = REGEX_DOWNLOADTRACK.matcher((CharSequence) queryParams.get(QueryParams.DOWNLOAD));
+        assertTrue(m.matches());
+        assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
+        assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
+        assertEquals("unknown", m.group(3));
     }
 
     @Test

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -1,8 +1,6 @@
 package org.piwik.sdk;
 
 import android.app.Application;
-import android.content.Context;
-import android.content.pm.PackageInfo;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -18,6 +16,8 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -30,12 +30,12 @@ import static org.junit.Assert.assertTrue;
 @Config(emulateSdk = 18, manifest = Config.NONE)
 @RunWith(FullEnvTestRunner.class)
 public class TrackerTest {
-    final static String testAPIUrl = "http://example.com";
 
     public Tracker createTracker() throws MalformedURLException {
-        return Piwik.getInstance(Robolectric.application).newTracker(testAPIUrl, 1);
+        TestPiwikApplication app = (TestPiwikApplication) Robolectric.application;
+        return Piwik.getInstance(Robolectric.application).newTracker(app.getTrackerUrl(), app.getSiteId());
     }
-    
+
     public Piwik getPiwik() {
         return Piwik.getInstance(Robolectric.application);
     }
@@ -52,7 +52,7 @@ public class TrackerTest {
         Piwik piwik = Piwik.getInstance(app);
         piwik.setDryRun(true);
         piwik.setAppOptOut(true);
-        Tracker tracker = piwik.newTracker(testAPIUrl, 1);
+        Tracker tracker = createTracker();
         //auto attach tracking screen view
         QuickTrack.bindToApp(app, tracker);
 
@@ -411,16 +411,30 @@ public class TrackerTest {
 
     }
 
+    private final Pattern REGEX_DOWNLOADTRACK = Pattern.compile("(?:https?:\\/\\/)([\\w.]+)(?::)([\\d]+)(?:\\/)([\\W\\w]+)");
+
     @Test
     public void testTrackNewAppDownload() throws Exception {
         Tracker tracker = createTracker();
-        tracker.trackNewAppDownload(Robolectric.application);
-        checkNewAppDownload(parseEventUrl(tracker.getLastEvent()));
+        tracker.trackNewAppDownload(Robolectric.application, Tracker.ExtraIdentifier.APK_CHECKSUM);
+        QueryHashMap queryParams = parseEventUrl(tracker.getLastEvent());
+        checkNewAppDownload(queryParams);
+        Matcher m = REGEX_DOWNLOADTRACK.matcher((CharSequence) queryParams.get(QueryParams.DOWNLOAD));
+        assertTrue(m.matches());
+        assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
+        assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
+        assertEquals(TestPiwikApplication.FAKE_APK_DATA_MD5, m.group(3));
 
         tracker.clearLastEvent();
 
-        tracker.trackNewAppDownload(Robolectric.application);
-        checkNewAppDownload(parseEventUrl(tracker.getLastEvent()));
+        tracker.trackNewAppDownload(Robolectric.application, Tracker.ExtraIdentifier.INSTALLER_PACKAGENAME);
+        queryParams = parseEventUrl(tracker.getLastEvent());
+        checkNewAppDownload(queryParams);
+        m = REGEX_DOWNLOADTRACK.matcher((CharSequence) queryParams.get(QueryParams.DOWNLOAD));
+        assertTrue(m.matches());
+        assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
+        assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
+        assertEquals(TestPiwikApplication.INSTALLER_PACKAGENAME, m.group(3));
     }
 
     @Test

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -1,6 +1,8 @@
 package org.piwik.sdk;
 
 import android.app.Application;
+import android.content.Context;
+import android.content.pm.PackageInfo;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -390,12 +392,12 @@ public class TrackerTest {
     @Test
     public void testTrackNewAppDownload() throws Exception {
         Tracker tracker = createTracker();
-        tracker.trackNewAppDownload();
+        tracker.trackNewAppDownload(Robolectric.application);
         checkNewAppDownload(parseEventUrl(tracker.getLastEvent()));
 
         tracker.clearLastEvent();
 
-        tracker.trackNewAppDownload();
+        tracker.trackNewAppDownload(Robolectric.application);
         checkNewAppDownload(parseEventUrl(tracker.getLastEvent()));
     }
 

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -180,21 +180,21 @@ public class TrackerTest {
         assertTrue(queryParams.get(QueryParams.URL_PATH).equals("http://my-domain.com/test/test"));
     }
 
-    @Test(expected=IllegalArgumentException.class) 
+    @Test(expected=IllegalArgumentException.class)
     public void testSetTooShortVistorId() {
         String tooShortVisitorId = "0123456789ab";
         dummyTracker.setVisitorId(tooShortVisitorId);
         assertNotEquals(tooShortVisitorId, dummyTracker.getVisitorId());
     }
 
-    @Test(expected=IllegalArgumentException.class) 
+    @Test(expected=IllegalArgumentException.class)
     public void testSetTooLongVistorId() {
         String tooLongVisitorId = "0123456789abcdefghi";
         dummyTracker.setVisitorId(tooLongVisitorId);
         assertNotEquals(tooLongVisitorId, dummyTracker.getVisitorId());
     }
 
-    @Test(expected=IllegalArgumentException.class) 
+    @Test(expected=IllegalArgumentException.class)
     public void testSetVistorIdWithInvalidCharacters() {
         String invalidCharacterVisitorId = "01234-6789-ghief";
         dummyTracker.setVisitorId(invalidCharacterVisitorId);
@@ -409,12 +409,12 @@ public class TrackerTest {
 
     @Test
     public void testTrackNewAppDownload() throws Exception {
-        dummyTracker.trackNewAppDownload();
+        dummyTracker.trackNewAppDownload(dummyApp);
         checkNewAppDownload(parseEventUrl(dummyTracker.getLastEvent()));
 
         dummyTracker.clearLastEvent();
 
-        dummyTracker.trackNewAppDownload();
+        dummyTracker.trackNewAppDownload(dummyApp);
         checkNewAppDownload(parseEventUrl(dummyTracker.getLastEvent()));
     }
 
@@ -517,7 +517,7 @@ public class TrackerTest {
         System.setProperty("http.agent", "aUserAgent");
 
         assertEquals(dummyTracker.getUserAgent(), defaultUserAgent);
-        
+
         dummyTracker.setUserAgent(customUserAgent);
         assertEquals(dummyTracker.getUserAgent(), customUserAgent);
 


### PR DESCRIPTION
This is a major enhancement of tracking app downloads.

Previous download stats looked like this:
```
http://packagename/
```
This just allows us to know the app was downloaded, which isn't really a lot.

Now depending on the option it looks like this: ![exampledownloadstat](https://cloud.githubusercontent.com/assets/1439229/6879452/ee7e3160-d4f5-11e4-8772-5dcd2344c7fa.PNG)
```
http://packagename:versioncode/apk-md5-checksum
http://packagename:versioncode/installer-packagename
```
It now not only tells us that the app was downloaded, but also what version of it was downloaded.

* *ExtraIdentifier.INSTALLER_PACKAGENAME* is useful if the same app is deployed on different appstores. Most major appstores set this field (Google/Amazon/Samsung) giving you can overview where your downloads are coming from. Note: This value can be set by tools and the user so some random values will appear in the stats.
* *ExtraIdentifier.APK_CHECKSUM* When your app is in the wild it will sooner or later get changed or "modified", choosing this stat gives you an overview over the differation incarnations there are. Some app stores (e.g. Amazon) modify the apk too. If you match the checksums to it's origin this option becomes even more interesting.

This PR also changes the "trackAppDownload" to only trigger ONCE per VERSION, so after each update it fires once.

The default option with "trackAppDownload" is *INSTALLER_PACKAGENAME*. I do consider the checksum more interesting, but the installer name is "easier accessible" for new developers using this. Additionally the checksum is computational expensive and needs to be done on a thread.