### PR TITLE
Making logging optional

### DIFF
--- a/demo_app/src/main/java/com/piwik/demo/DemoActivity.java
+++ b/demo_app/src/main/java/com/piwik/demo/DemoActivity.java
@@ -13,13 +13,14 @@ import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+
 import org.piwik.sdk.PiwikApplication;
+import org.piwik.sdk.tools.Logy;
 
 
 public class DemoActivity extends ActionBarActivity {
@@ -61,9 +62,9 @@ public class DemoActivity extends ActionBarActivity {
         try {
             WifiManager wm = (WifiManager) getSystemService(Context.WIFI_SERVICE);
             userId = wm.getConnectionInfo().getMacAddress();
-            Log.i("user_id", "wifi mac " + userId);
+            Logy.i("user_id", "wifi mac " + userId);
         } catch (Exception e) {
-            Log.e("user_id", "wifi is not available", e);
+            Logy.e("user_id", "wifi is not available", e);
             userId = null;
         }
 
@@ -81,7 +82,7 @@ public class DemoActivity extends ActionBarActivity {
             result = 31 * result + Build.BOOTLOADER.hashCode();
 
             userId = Long.toString(result);
-            Log.i("user_id", "android.os.Build used " + userId);
+            Logy.i("user_id", "android.os.Build used " + userId);
         }
 
         return userId;

--- a/demo_app/src/main/java/com/piwik/demo/SettingsActivity.java
+++ b/demo_app/src/main/java/com/piwik/demo/SettingsActivity.java
@@ -11,13 +11,14 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+
 import org.piwik.sdk.PiwikApplication;
 import org.piwik.sdk.QuickTrack;
+import org.piwik.sdk.tools.Logy;
 
 
 public class SettingsActivity extends Activity {
@@ -66,7 +67,7 @@ public class SettingsActivity extends Activity {
                             ((PiwikApplication) getApplication()).getTracker()
                                     .setDispatchInterval(interval);
                         } catch (NumberFormatException e) {
-                            Log.d("not a number", charSequence.toString());
+                            Logy.d("not a number", charSequence.toString());
                         }
                     }
 
@@ -97,7 +98,7 @@ public class SettingsActivity extends Activity {
                                     .setSessionTimeout(timeoutMin * 60);
                         } catch (NumberFormatException e) {
                             ((EditText) settingsActivity.findViewById(R.id.sessionTimeoutInput)).setText("30");
-                            Log.d("not a number", charSequence.toString());
+                            Logy.d("not a number", charSequence.toString());
                         }
                     }
 

--- a/piwik_sdk/src/main/java/org/piwik/sdk/CustomVariables.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/CustomVariables.java
@@ -7,9 +7,9 @@
 
 package org.piwik.sdk;
 
-import android.util.Log;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.piwik.sdk.tools.Logy;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -52,18 +52,18 @@ public class CustomVariables extends HashMap<String, JSONArray> {
         if (index > 0 && index <= MAX_VARIABLES && name != null & value != null) {
 
             if (name.length() > MAX_LENGTH) {
-                Log.w(Tracker.LOGGER_TAG, String.format("Name is too long %s", name));
+                Logy.w(Tracker.LOGGER_TAG, String.format("Name is too long %s", name));
                 name = name.substring(0, MAX_LENGTH);
             }
 
             if (value.length() > MAX_LENGTH) {
-                Log.w(Tracker.LOGGER_TAG, String.format("Value is too long %s", value));
+                Logy.w(Tracker.LOGGER_TAG, String.format("Value is too long %s", value));
                 value = value.substring(0, MAX_LENGTH);
             }
 
             return put(Integer.toString(index), new JSONArray(Arrays.asList(name, value)));
         }
-        Log.d(Tracker.LOGGER_TAG, "Index is out of range or name/value is null");
+        Logy.d(Tracker.LOGGER_TAG, "Index is out of range or name/value is null");
         return null;
     }
 
@@ -77,7 +77,7 @@ public class CustomVariables extends HashMap<String, JSONArray> {
         if (values.length() == 2 && index != null) {
             return super.put(index, values);
         }
-        Log.d(Tracker.LOGGER_TAG, "value length should be equal 2");
+        Logy.d(Tracker.LOGGER_TAG, "value length should be equal 2");
         return null;
     }
 

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -10,6 +10,8 @@ package org.piwik.sdk;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import org.piwik.sdk.tools.Logy;
+
 import java.net.MalformedURLException;
 
 
@@ -21,6 +23,7 @@ public class Piwik {
     private boolean mDryRun = false;
 
     private static Piwik sInstance;
+    private boolean mDebug = BuildConfig.DEBUG;
 
     public static synchronized Piwik getInstance(Context context) {
         if (sInstance == null)
@@ -69,6 +72,15 @@ public class Piwik {
 
     public boolean isDryRun() {
         return mDryRun;
+    }
+    
+    public boolean isDebug() {
+        return mDebug;
+    }
+
+    public void setDebug(boolean debug) {
+        mDebug = debug;
+        Logy.sLoglevel = debug ? Logy.VERBOSE : Logy.NORMAL;
     }
 
     /**

--- a/piwik_sdk/src/main/java/org/piwik/sdk/PiwikExceptionHandler.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/PiwikExceptionHandler.java
@@ -7,7 +7,7 @@
 
 package org.piwik.sdk;
 
-import android.util.Log;
+import org.piwik.sdk.tools.Logy;
 
 /**
  * An exception handler that wraps the existing exception handler and dispatches event to a {@link org.piwik.sdk.Tracker}.
@@ -44,7 +44,7 @@ public class PiwikExceptionHandler implements Thread.UncaughtExceptionHandler {
             // Immediately dispatch as the app might be dying after rethrowing the exception
             getTracker().dispatch();
         } catch (Exception e) {
-            Log.e(Tracker.LOGGER_TAG, "Couldn't track uncaught exception", e);
+            Logy.e(Tracker.LOGGER_TAG, "Couldn't track uncaught exception", e);
         } finally {
             // re-throw critical exception further to the os (important)
             if (getDefaultExceptionHandler() != null && getDefaultExceptionHandler() != this) {

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -9,9 +9,9 @@ package org.piwik.sdk;
 
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
-import android.util.Log;
 
 import org.piwik.sdk.tools.DeviceHelper;
+import org.piwik.sdk.tools.Logy;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -223,7 +223,7 @@ public class Tracker implements Dispatchable<Integer> {
     @Override
     public void dispatchingCompleted(Integer count) {
         isDispatching = false;
-        Log.d(Tracker.LOGGER_TAG, String.format("dispatched %s url(s)", count));
+        Logy.d(Tracker.LOGGER_TAG, String.format("dispatched %s url(s)", count));
     }
 
     @Override
@@ -635,7 +635,7 @@ public class Tracker implements Dispatchable<Integer> {
             StackTraceElement trace = ex.getStackTrace()[0];
             className = trace.getClassName() + "/" + trace.getMethodName() + ":" + trace.getLineNumber();
         } catch (Exception e) {
-            Log.w(Tracker.LOGGER_TAG, "Couldn't get stack info", e);
+            Logy.w(Tracker.LOGGER_TAG, "Couldn't get stack info", e);
             className = ex.getClass().getName();
         }
         String actionName = "exception/" + (isFatal ? "fatal/" : "") + (className + "/") + description;
@@ -675,9 +675,9 @@ public class Tracker implements Dispatchable<Integer> {
         String event = getQuery();
         if (mPiwik.isOptOut()) {
             lastEvent = event;
-            Log.d(Tracker.LOGGER_TAG, String.format("URL omitted due to opt out: %s", event));
+            Logy.d(Tracker.LOGGER_TAG, String.format("URL omitted due to opt out: %s", event));
         } else {
-            Log.d(Tracker.LOGGER_TAG, String.format("URL added to the queue: %s", event));
+            Logy.d(Tracker.LOGGER_TAG, String.format("URL added to the queue: %s", event));
             queue.add(event);
 
             tryDispatch();

--- a/piwik_sdk/src/main/java/org/piwik/sdk/TrackerBulkURLProcessor.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/TrackerBulkURLProcessor.java
@@ -11,7 +11,7 @@ package org.piwik.sdk;
 import android.annotation.TargetApi;
 import android.os.AsyncTask;
 import android.os.Build;
-import android.util.Log;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.ClientProtocolException;
@@ -25,6 +25,7 @@ import org.apache.http.message.BasicHeader;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.protocol.HTTP;
 import org.json.JSONObject;
+import org.piwik.sdk.tools.Logy;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -133,9 +134,9 @@ public class TrackerBulkURLProcessor extends AsyncTask<TrackerBulkURLWrapper, In
 
             return doRequest(post, jsonBody);
         } catch (URISyntaxException e) {
-            Log.w(Tracker.LOGGER_TAG, String.format("URI Syntax Error %s", url.toString()), e);
+            Logy.w(Tracker.LOGGER_TAG, String.format("URI Syntax Error %s", url.toString()), e);
         } catch (UnsupportedEncodingException e) {
-            Log.w(Tracker.LOGGER_TAG, String.format("Unsupported Encoding %s", jsonBody), e);
+            Logy.w(Tracker.LOGGER_TAG, String.format("Unsupported Encoding %s", jsonBody), e);
         }
 
         return false;
@@ -147,19 +148,19 @@ public class TrackerBulkURLProcessor extends AsyncTask<TrackerBulkURLWrapper, In
         HttpResponse response;
 
         if (dryRun) {
-            Log.i(Tracker.LOGGER_TAG, "Request wasn't send due to dry run is on");
+            Logy.i(Tracker.LOGGER_TAG, "Request wasn't send due to dry run is on");
             logRequest(requestBase, body);
         } else {
             try {
                 response = client.execute(requestBase);
                 int statusCode = response.getStatusLine().getStatusCode();
-                Log.d(Tracker.LOGGER_TAG, String.format("status code %s", statusCode));
+                Logy.d(Tracker.LOGGER_TAG, String.format("status code %s", statusCode));
                 return statusCode == HttpStatus.SC_NO_CONTENT || statusCode == HttpStatus.SC_OK;
 
             } catch (ClientProtocolException e) {
-                Log.w(Tracker.LOGGER_TAG, "Cannot send request", e);
+                Logy.w(Tracker.LOGGER_TAG, "Cannot send request", e);
             } catch (IOException e) {
-                Log.w(Tracker.LOGGER_TAG, "Cannot send request", e);
+                Logy.w(Tracker.LOGGER_TAG, "Cannot send request", e);
             }
 
             logRequest(requestBase, body);
@@ -169,9 +170,9 @@ public class TrackerBulkURLProcessor extends AsyncTask<TrackerBulkURLWrapper, In
     }
 
     private void logRequest(HttpRequestBase requestBase, String body) {
-        Log.i(Tracker.LOGGER_TAG, "\tURI: " + requestBase.getURI().toString());
+        Logy.i(Tracker.LOGGER_TAG, "\tURI: " + requestBase.getURI().toString());
         if (body != null) {
-            Log.i(Tracker.LOGGER_TAG, "\tBODY: " + body);
+            Logy.i(Tracker.LOGGER_TAG, "\tBODY: " + body);
         }
     }
 
@@ -185,7 +186,7 @@ public class TrackerBulkURLProcessor extends AsyncTask<TrackerBulkURLWrapper, In
         try {
             return URLEncoder.encode(param, "UTF-8").replaceAll("\\+", "%20");
         } catch (UnsupportedEncodingException e) {
-            Log.w(Tracker.LOGGER_TAG, String.format("Cannot encode %s", param), e);
+            Logy.w(Tracker.LOGGER_TAG, String.format("Cannot encode %s", param), e);
             return "";
         } catch (NullPointerException e) {
             return "";

--- a/piwik_sdk/src/main/java/org/piwik/sdk/TrackerBulkURLWrapper.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/TrackerBulkURLWrapper.java
@@ -8,10 +8,11 @@
 package org.piwik.sdk;
 
 import android.text.TextUtils;
-import android.util.Log;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.piwik.sdk.tools.Logy;
 
 import java.net.URL;
 import java.util.Iterator;
@@ -85,7 +86,7 @@ public class TrackerBulkURLWrapper {
         List<String> pageElements = events.subList(page.fromIndex, page.toIndex);
 
         if(pageElements.size() == 0){
-            Log.w(Tracker.LOGGER_TAG, "Empty page");
+            Logy.w(Tracker.LOGGER_TAG, "Empty page");
             return null;
         }
 
@@ -97,8 +98,8 @@ public class TrackerBulkURLWrapper {
                 params.put(QueryParams.AUTHENTICATION_TOKEN.toString(), authToken);
             }
         } catch (JSONException e) {
-            Log.w(Tracker.LOGGER_TAG, "Cannot create json object", e);
-            Log.i(Tracker.LOGGER_TAG, TextUtils.join(", ", pageElements));
+            Logy.w(Tracker.LOGGER_TAG, "Cannot create json object", e);
+            Logy.i(Tracker.LOGGER_TAG, TextUtils.join(", ", pageElements));
             return null;
         }
         return params;

--- a/piwik_sdk/src/main/java/org/piwik/sdk/tools/DeviceHelper.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/tools/DeviceHelper.java
@@ -10,7 +10,6 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
 
@@ -40,7 +39,7 @@ public class DeviceHelper {
             WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
             display = wm.getDefaultDisplay();
         } catch (NullPointerException e) {
-            Log.e(LOGGER_TAG, "Window service was not available from this context");
+            Logy.e(LOGGER_TAG, "Window service was not available from this context");
             return null;
         }
 
@@ -58,7 +57,7 @@ public class DeviceHelper {
                 width = (int) getRawWidth.invoke(display);
                 height = (int) getRawHeight.invoke(display);
             } catch (Exception e) {
-                Log.w(LOGGER_TAG, "Reflection of getRawWidth/getRawHeight failed on API14-16 unexpectedly.");
+                Logy.w(LOGGER_TAG, "Reflection of getRawWidth/getRawHeight failed on API14-16 unexpectedly.");
             }
         }
 

--- a/piwik_sdk/src/main/java/org/piwik/sdk/tools/Logy.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/tools/Logy.java
@@ -1,0 +1,67 @@
+/*
+ * Android SDK for Piwik
+ *
+ * @link https://github.com/piwik/piwik-android-sdk
+ * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ */
+
+package org.piwik.sdk.tools;
+
+import android.util.Log;
+
+import org.piwik.sdk.BuildConfig;
+
+/**
+ * Wrapper class for {@link android.util.Log} that allows to fine tune what gets logged.
+ */
+public class Logy {
+    public static final int SILENT = -1;
+    public static final int NORMAL = 0;
+    public static final int DEBUG = 1;
+    public static final int VERBOSE = 2;
+
+    public static int sLoglevel = BuildConfig.DEBUG ? VERBOSE : NORMAL;
+
+    public static void v(String c, String s) {
+        if (sLoglevel >= VERBOSE) {
+            Log.v(c, s);
+        }
+    }
+
+    public static void d(String c, String s) {
+        if (sLoglevel >= DEBUG) {
+            Log.d(c, s);
+        }
+    }
+
+    public static void i(String c, String s) {
+        if (sLoglevel >= NORMAL) {
+            Log.i(c, s);
+        }
+    }
+
+    public static void w(String c, String s) {
+        if (sLoglevel >= SILENT) {
+            Log.w(c, s);
+        }
+    }
+
+    public static void w(String c, String s, Throwable tr) {
+        if (sLoglevel >= SILENT) {
+            Log.w(c, s, tr);
+        }
+    }
+
+    public static void e(String c, String s) {
+        if (sLoglevel >= SILENT) {
+            Log.e(c, s);
+        }
+    }
+
+    public static void e(String c, String s, Throwable tr) {
+        if (sLoglevel >= SILENT) {
+            Log.e(c, s, tr);
+        }
+    }
+
+}


### PR DESCRIPTION
This replaces all *Log* calls with the wrapper *Logy*.
Debugging can be turned on and off now and in a release version only .i .w .e get printed.
Previously every dispatch printed 2 log statements which was kinda spammy.