### PR TITLE
Persist userid

### DIFF
--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -278,8 +278,10 @@ public class Tracker implements Dispatchable<Integer> {
      *               Note that if the user-id is NULL, the tracker will automatically generate a new one.
      */
     public Tracker setUserId(String userId) {
-        mUserId = userId;
-        getSharedPreferences().edit().putString(PREF_KEY_TRACKER_USERID, mUserId).commit();
+        if (!"".equals(userId)) {
+            mUserId = userId;
+            getSharedPreferences().edit().putString(PREF_KEY_TRACKER_USERID, mUserId).commit();
+        }
         return this;
     }
 
@@ -581,7 +583,8 @@ public class Tracker implements Dispatchable<Integer> {
 
     /**
      * Fires a download for an arbitrary app once per update.
-     * @param app the app to track
+     *
+     * @param app   the app to track
      * @param extra {@link org.piwik.sdk.Tracker.ExtraIdentifier#APK_CHECKSUM} or {@link org.piwik.sdk.Tracker.ExtraIdentifier#INSTALLER_PACKAGENAME}
      * @return this tracker for chaining
      */

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -16,6 +16,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -33,7 +34,7 @@ public class TrackerTest {
     public Tracker createTracker() throws MalformedURLException {
         return Piwik.getInstance(Robolectric.application).newTracker(testAPIUrl, 1);
     }
-    
+
     public Piwik getPiwik() {
         return Piwik.getInstance(Robolectric.application);
     }
@@ -204,24 +205,15 @@ public class TrackerTest {
         tracker.setUserId("test");
         assertEquals(tracker.getUserId(), "test");
 
-        tracker.clearUserId();
-        assertNull(tracker.getUserId());
-
-        tracker.setUserId("");
-        assertNull(tracker.getUserId());
-
         tracker.setUserId(null);
-        assertNull(tracker.getUserId());
+        assertNotEquals("test", tracker.getUserId());
+        assertNotNull(tracker.getUserId());
 
-        tracker.setUserId("X98F6bcd4621d373");
-        assertEquals(tracker.getUserId(), "X98F6bcd4621d373");
-    }
+        String uuid = UUID.randomUUID().toString();
+        tracker.setUserId(uuid);
+        assertEquals(uuid, tracker.getUserId());
 
-    @Test
-    public void testSetUserIdLong() throws Exception {
-        Tracker tracker = createTracker();
-        tracker.setUserId(123456);
-        assertEquals(tracker.getUserId(), "123456");
+        assertEquals(uuid, createTracker().getUserId());
     }
 
     @Test

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -209,6 +209,9 @@ public class TrackerTest {
         tracker.setUserId("test");
         assertEquals(tracker.getUserId(), "test");
 
+        tracker.setUserId("");
+        assertEquals(tracker.getUserId(), "test");
+
         tracker.setUserId(null);
         assertNotEquals("test", tracker.getUserId());
         assertNotNull(tracker.getUserId());


### PR DESCRIPTION
* Removed setUserId that took a *long* paramter, was confusing you can just as well pass the long as string
* Altered the javadocs which stated that the userid is somehow hashed, which isn't the case
* The userid is now persisted in the preferences
* If no userid is set (or persisted) the sdk will create a new userid (random UUID) and persist it
* You can set the userid to NULL to clear, but not to an empty string
* It's no longer possible to have no userid, because why would you want that?