### PR TITLE
Referrer tracking

### DIFF
--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -408,6 +408,7 @@ public class TrackerTest {
         assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
         assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
         assertEquals(TestPiwikApplication.FAKE_APK_DATA_MD5, m.group(3));
+        assertEquals(TestPiwikApplication.INSTALLER_PACKAGENAME, queryParams.get(QueryParams.REFERRER));
 
         tracker.clearLastEvent();
 
@@ -419,6 +420,7 @@ public class TrackerTest {
         assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
         assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
         assertEquals(TestPiwikApplication.INSTALLER_PACKAGENAME, m.group(3));
+        assertEquals(TestPiwikApplication.INSTALLER_PACKAGENAME, queryParams.get(QueryParams.REFERRER));
 
         tracker.clearLastEvent();
 
@@ -432,6 +434,7 @@ public class TrackerTest {
         assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
         assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
         assertEquals("unknown", m.group(3));
+        assertEquals("unknown", queryParams.get(QueryParams.REFERRER));
     }
 
     @Test


### PR DESCRIPTION
Should be merged after #46 

Adds usage of the referrer field. For each call of the *trackDownload()* method that triggers (i.e. has not been called), the outgoing query will contain the installerpackagename of the tracked download for the referrer parameter.

This basically makes the Referrer section of Piwik useful.