### PR TITLE
Fixed Tracker generated user-id being persisted but not used. 

### DIFF
--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -76,7 +76,7 @@ public class Tracker {
      * @param piwik     piwik object used to gain access to application params such as name, resolution or lang
      * @throws MalformedURLException
      */
-    protected Tracker(@NonNull final String url, @NonNull int siteId, String authToken, @NonNull Piwik piwik) throws MalformedURLException {
+    protected Tracker(@NonNull final String url, int siteId, String authToken, @NonNull Piwik piwik) throws MalformedURLException {
         String checkUrl = url;
         if (checkUrl.endsWith("piwik.php") || checkUrl.endsWith("piwik-proxy.php")) {
             mApiUrl = new URL(checkUrl);
@@ -92,9 +92,12 @@ public class Tracker {
         mDispatcher = new Dispatcher(mPiwik, mApiUrl, authToken);
 
         String userId = getSharedPreferences().getString(PREF_KEY_TRACKER_USERID, null);
-        if (userId == null)
-            getSharedPreferences().edit().putString(PREF_KEY_TRACKER_USERID, UUID.randomUUID().toString()).commit();
+        if (userId == null) {
+            userId = UUID.randomUUID().toString();
+            getSharedPreferences().edit().putString(PREF_KEY_TRACKER_USERID, userId).commit();
+        }
         mDefaultTrackMe.set(QueryParams.USER_ID, userId);
+
         mDefaultTrackMe.set(QueryParams.SESSION_START, DEFAULT_TRUE_VALUE);
 
         String resolution = DEFAULT_UNKNOWN_VALUE;

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -217,6 +217,8 @@ public class TrackerTest {
     @Test
     public void testSetUserId() throws Exception {
         Tracker tracker = createTracker();
+        assertNotNull(tracker.getDefaultTrackMe().get(QueryParams.USER_ID));
+
         tracker.setUserId("test");
         assertEquals(tracker.getUserId(), "test");
 
@@ -229,7 +231,6 @@ public class TrackerTest {
         String uuid = UUID.randomUUID().toString();
         tracker.setUserId(uuid);
         assertEquals(uuid, tracker.getUserId());
-
         assertEquals(uuid, createTracker().getUserId());
     }
 


### PR DESCRIPTION
Didn't notice this as i was explicitly setting the user-id.
If no user-id existed on first Tracker creation, one was created&persisted but not used until creating the Tracker again.
Also added test to catch this.