### PR TITLE
Feature: Visit count, frequency, interval

### DIFF
--- a/piwik_sdk/build.gradle
+++ b/piwik_sdk/build.gradle
@@ -9,7 +9,7 @@ android {
     buildToolsVersion '22.0.1'
 
     defaultConfig {
-        minSdkVersion 7
+        minSdkVersion 10
         targetSdkVersion 22
         versionCode 1
         versionName '0.0.1'
@@ -118,7 +118,7 @@ android.libraryVariants.all { variant ->
 
         description "Generates Javadoc for $variant.name."
 
-        options.memberLevel = org.gradle.external.javadoc.JavadocMemberLevel.PRIVATE
+        options.memberLevel = JavadocMemberLevel.PRIVATE
         options.links("http://docs.oracle.com/javase/7/docs/api/");
         options.links("http://developer.android.com/reference/reference/");
         exclude '**/BuildConfig.java'

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -51,7 +51,7 @@ public class Piwik {
      * @deprecated Use {@link #newTracker(String, int)} as there are security concerns over the authToken.
      */
     @Deprecated
-    public Tracker newTracker(@NonNull String trackerUrl, @NonNull int siteId, String authToken) throws MalformedURLException {
+    public synchronized Tracker newTracker(@NonNull String trackerUrl, int siteId, String authToken) throws MalformedURLException {
         return new Tracker(trackerUrl, siteId, authToken, this);
     }
 
@@ -61,7 +61,7 @@ public class Piwik {
      * @return Tracker object
      * @throws MalformedURLException
      */
-    public Tracker newTracker(@NonNull String trackerUrl, @NonNull int siteId) throws MalformedURLException {
+    public synchronized Tracker newTracker(@NonNull String trackerUrl, int siteId) throws MalformedURLException {
         return new Tracker(trackerUrl, siteId, null, this);
     }
 

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -74,7 +74,7 @@ public class Piwik {
      */
     public void setOptOut(boolean optOut) {
         mOptOut = optOut;
-        getSharedPreferences().edit().putBoolean(PREFERENCE_KEY_OPTOUT, optOut).commit();
+        getSharedPreferences().edit().putBoolean(PREFERENCE_KEY_OPTOUT, optOut).apply();
     }
 
     /**

--- a/piwik_sdk/src/main/java/org/piwik/sdk/TrackMe.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/TrackMe.java
@@ -51,6 +51,11 @@ public class TrackMe {
         return this;
     }
 
+    public synchronized TrackMe set(@NonNull QueryParams key, long value) {
+        set(key, Long.toString(value));
+        return this;
+    }
+
     public synchronized boolean has(@NonNull QueryParams queryParams) {
         return mQueryParams.containsKey(queryParams.toString());
     }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -45,6 +45,7 @@ public class Tracker {
     protected static final String PREF_KEY_TRACKER_USERID = "tracker.userid";
     protected static final String PREF_KEY_TRACKER_FIRSTVISIT = "tracker.firstvisit";
     protected static final String PREF_KEY_TRACKER_VISITCOUNT = "tracker.visitcount";
+    protected static final String PREF_KEY_TRACKER_PREVIOUSVISIT = "tracker.previousvisit";
 
     /**
      * The ID of the website we're tracking a visit/action for.
@@ -125,6 +126,11 @@ public class Tracker {
         int visitCount = getSharedPreferences().getInt(PREF_KEY_TRACKER_VISITCOUNT, 0);
         getSharedPreferences().edit().putInt(PREF_KEY_TRACKER_VISITCOUNT, ++visitCount).commit();
         mDefaultTrackMe.set(QueryParams.TOTAL_NUMBER_OF_VISITS, visitCount);
+
+        // TODO This isn't thread safe if multiple tracker instances are used
+        long previousVisit = getSharedPreferences().getLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis());
+        mDefaultTrackMe.set(QueryParams.PREVIOUS_VISIT_TIMESTAMP, previousVisit);
+        getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis()).commit();
     }
 
     public Piwik getPiwik() {
@@ -581,6 +587,7 @@ public class Tracker {
         trackMe.trySet(QueryParams.COUNTRY, mDefaultTrackMe.get(QueryParams.COUNTRY));
         trackMe.trySet(QueryParams.FIRST_VISIT_TIMESTAMP, mDefaultTrackMe.get(QueryParams.FIRST_VISIT_TIMESTAMP));
         trackMe.trySet(QueryParams.TOTAL_NUMBER_OF_VISITS, mDefaultTrackMe.get(QueryParams.TOTAL_NUMBER_OF_VISITS));
+        trackMe.trySet(QueryParams.PREVIOUS_VISIT_TIMESTAMP, mDefaultTrackMe.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP));
     }
 
     /**

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -43,6 +43,7 @@ public class Tracker {
 
     // Sharedpreference keys for persisted values
     private static final String PREF_KEY_TRACKER_USERID = "tracker.userid";
+    private static final String PREF_KEY_TRACKER_FIRSTVISIT = "tracker.firstvisit";
 
     /**
      * The ID of the website we're tracking a visit/action for.
@@ -110,6 +111,13 @@ public class Tracker {
         mDefaultTrackMe.set(QueryParams.LANGUAGE, DeviceHelper.getUserLanguage());
         mDefaultTrackMe.set(QueryParams.COUNTRY, DeviceHelper.getUserCountry());
         mDefaultTrackMe.set(QueryParams.VISITOR_ID, makeRandomVisitorId());
+
+        long firstVisitTime = getSharedPreferences().getLong(PREF_KEY_TRACKER_FIRSTVISIT, -1);
+        if (firstVisitTime == -1) {
+            firstVisitTime = System.currentTimeMillis();
+            getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_FIRSTVISIT, firstVisitTime).commit();
+        }
+        mDefaultTrackMe.set(QueryParams.FIRST_VISIT_TIMESTAMP, firstVisitTime);
     }
 
     public Piwik getPiwik() {
@@ -475,13 +483,13 @@ public class Tracker {
             }
             installationIdentifier.append("/").append(extraIdentifier);
 
-        return track(new TrackMe()
-                .set(QueryParams.EVENT_CATEGORY, "Application")
-                .set(QueryParams.EVENT_ACTION, "downloaded")
-                .set(QueryParams.ACTION_NAME, "application/downloaded")
-                .set(QueryParams.URL_PATH, "/application/downloaded")
-                .set(QueryParams.DOWNLOAD, installationIdentifier.toString())
-                .set(QueryParams.REFERRER, installerPackageName));
+            return track(new TrackMe()
+                    .set(QueryParams.EVENT_CATEGORY, "Application")
+                    .set(QueryParams.EVENT_ACTION, "downloaded")
+                    .set(QueryParams.ACTION_NAME, "application/downloaded")
+                    .set(QueryParams.URL_PATH, "/application/downloaded")
+                    .set(QueryParams.DOWNLOAD, installationIdentifier.toString())
+                    .set(QueryParams.REFERRER, installerPackageName));
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();
             return this;
@@ -564,6 +572,7 @@ public class Tracker {
         trackMe.trySet(QueryParams.USER_AGENT, mDefaultTrackMe.get(QueryParams.USER_AGENT));
         trackMe.trySet(QueryParams.LANGUAGE, mDefaultTrackMe.get(QueryParams.LANGUAGE));
         trackMe.trySet(QueryParams.COUNTRY, mDefaultTrackMe.get(QueryParams.COUNTRY));
+        trackMe.trySet(QueryParams.FIRST_VISIT_TIMESTAMP, mDefaultTrackMe.get(QueryParams.FIRST_VISIT_TIMESTAMP));
     }
 
     /**

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -114,7 +114,6 @@ public class Tracker {
         mDefaultTrackMe.set(QueryParams.COUNTRY, DeviceHelper.getUserCountry());
         mDefaultTrackMe.set(QueryParams.VISITOR_ID, makeRandomVisitorId());
 
-        // TODO This isn't thread safe if multiple tracker instances are used
         long firstVisitTime = getSharedPreferences().getLong(PREF_KEY_TRACKER_FIRSTVISIT, -1);
         if (firstVisitTime == -1) {
             firstVisitTime = System.currentTimeMillis();
@@ -122,12 +121,10 @@ public class Tracker {
         }
         mDefaultTrackMe.set(QueryParams.FIRST_VISIT_TIMESTAMP, firstVisitTime);
 
-        // TODO This isn't thread safe if multiple tracker instances are used
         int visitCount = getSharedPreferences().getInt(PREF_KEY_TRACKER_VISITCOUNT, 0);
         getSharedPreferences().edit().putInt(PREF_KEY_TRACKER_VISITCOUNT, ++visitCount).commit();
         mDefaultTrackMe.set(QueryParams.TOTAL_NUMBER_OF_VISITS, visitCount);
 
-        // TODO This isn't thread safe if multiple tracker instances are used
         long previousVisit = getSharedPreferences().getLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis());
         mDefaultTrackMe.set(QueryParams.PREVIOUS_VISIT_TIMESTAMP, previousVisit);
         getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis()).commit();

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -97,7 +97,7 @@ public class Tracker {
         String userId = getSharedPreferences().getString(PREF_KEY_TRACKER_USERID, null);
         if (userId == null) {
             userId = UUID.randomUUID().toString();
-            getSharedPreferences().edit().putString(PREF_KEY_TRACKER_USERID, userId).commit();
+            getSharedPreferences().edit().putString(PREF_KEY_TRACKER_USERID, userId).apply();
         }
         mDefaultTrackMe.set(QueryParams.USER_ID, userId);
 
@@ -117,17 +117,17 @@ public class Tracker {
         long firstVisitTime = getSharedPreferences().getLong(PREF_KEY_TRACKER_FIRSTVISIT, -1);
         if (firstVisitTime == -1) {
             firstVisitTime = System.currentTimeMillis();
-            getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_FIRSTVISIT, firstVisitTime).commit();
+            getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_FIRSTVISIT, firstVisitTime).apply();
         }
         mDefaultTrackMe.set(QueryParams.FIRST_VISIT_TIMESTAMP, firstVisitTime);
 
         int visitCount = getSharedPreferences().getInt(PREF_KEY_TRACKER_VISITCOUNT, 0);
-        getSharedPreferences().edit().putInt(PREF_KEY_TRACKER_VISITCOUNT, ++visitCount).commit();
+        getSharedPreferences().edit().putInt(PREF_KEY_TRACKER_VISITCOUNT, ++visitCount).apply();
         mDefaultTrackMe.set(QueryParams.TOTAL_NUMBER_OF_VISITS, visitCount);
 
         long previousVisit = getSharedPreferences().getLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis());
         mDefaultTrackMe.set(QueryParams.PREVIOUS_VISIT_TIMESTAMP, previousVisit);
-        getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis()).commit();
+        getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis()).apply();
     }
 
     public Piwik getPiwik() {
@@ -229,7 +229,7 @@ public class Tracker {
      */
     public Tracker setUserId(String userId) {
         mDefaultTrackMe.set(QueryParams.USER_ID, userId);
-        getSharedPreferences().edit().putString(PREF_KEY_TRACKER_USERID, userId).commit();
+        getSharedPreferences().edit().putString(PREF_KEY_TRACKER_USERID, userId).apply();
         return this;
     }
 
@@ -431,13 +431,12 @@ public class Tracker {
      * @return this tracker for chaining
      */
     public Tracker trackAppDownload(Context app, ExtraIdentifier extra) {
-        SharedPreferences prefs = mPiwik.getSharedPreferences();
         try {
             PackageInfo pkgInfo = app.getPackageManager().getPackageInfo(app.getPackageName(), 0);
             String firedKey = "downloaded:" + pkgInfo.packageName + ":" + pkgInfo.versionCode;
-            if (!prefs.getBoolean(firedKey, false)) {
+            if (!getSharedPreferences().getBoolean(firedKey, false)) {
                 trackNewAppDownload(app, extra);
-                prefs.edit().putBoolean(firedKey, true).commit();
+                getSharedPreferences().edit().putBoolean(firedKey, true).apply();
             }
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -42,8 +42,9 @@ public class Tracker {
     private static final String DEFAULT_API_VERSION_VALUE = "1";
 
     // Sharedpreference keys for persisted values
-    private static final String PREF_KEY_TRACKER_USERID = "tracker.userid";
-    private static final String PREF_KEY_TRACKER_FIRSTVISIT = "tracker.firstvisit";
+    protected static final String PREF_KEY_TRACKER_USERID = "tracker.userid";
+    protected static final String PREF_KEY_TRACKER_FIRSTVISIT = "tracker.firstvisit";
+    protected static final String PREF_KEY_TRACKER_VISITCOUNT = "tracker.visitcount";
 
     /**
      * The ID of the website we're tracking a visit/action for.
@@ -112,12 +113,18 @@ public class Tracker {
         mDefaultTrackMe.set(QueryParams.COUNTRY, DeviceHelper.getUserCountry());
         mDefaultTrackMe.set(QueryParams.VISITOR_ID, makeRandomVisitorId());
 
+        // TODO This isn't thread safe if multiple tracker instances are used
         long firstVisitTime = getSharedPreferences().getLong(PREF_KEY_TRACKER_FIRSTVISIT, -1);
         if (firstVisitTime == -1) {
             firstVisitTime = System.currentTimeMillis();
             getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_FIRSTVISIT, firstVisitTime).commit();
         }
         mDefaultTrackMe.set(QueryParams.FIRST_VISIT_TIMESTAMP, firstVisitTime);
+
+        // TODO This isn't thread safe if multiple tracker instances are used
+        int visitCount = getSharedPreferences().getInt(PREF_KEY_TRACKER_VISITCOUNT, 0);
+        getSharedPreferences().edit().putInt(PREF_KEY_TRACKER_VISITCOUNT, ++visitCount).commit();
+        mDefaultTrackMe.set(QueryParams.TOTAL_NUMBER_OF_VISITS, visitCount);
     }
 
     public Piwik getPiwik() {
@@ -573,6 +580,7 @@ public class Tracker {
         trackMe.trySet(QueryParams.LANGUAGE, mDefaultTrackMe.get(QueryParams.LANGUAGE));
         trackMe.trySet(QueryParams.COUNTRY, mDefaultTrackMe.get(QueryParams.COUNTRY));
         trackMe.trySet(QueryParams.FIRST_VISIT_TIMESTAMP, mDefaultTrackMe.get(QueryParams.FIRST_VISIT_TIMESTAMP));
+        trackMe.trySet(QueryParams.TOTAL_NUMBER_OF_VISITS, mDefaultTrackMe.get(QueryParams.TOTAL_NUMBER_OF_VISITS));
     }
 
     /**

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -45,7 +45,7 @@ public class TrackerTest {
     public void setup() {
         Piwik.getInstance(Robolectric.application).setDryRun(true);
         Piwik.getInstance(Robolectric.application).setOptOut(true);
-        Piwik.getInstance(Robolectric.application).getSharedPreferences().edit().clear().commit();
+        Piwik.getInstance(Robolectric.application).getSharedPreferences().edit().clear().apply();
     }
 
     @Test

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -602,6 +602,23 @@ public class TrackerTest {
         assertEquals(null, trackMe.get(QueryParams.USER_AGENT));
     }
 
+    @Test
+    public void testFirstVisitTimeStamp() throws Exception {
+        Tracker tracker = createTracker();
+        long firstVisitTimeStamp = Long.parseLong(tracker.getDefaultTrackMe().get(QueryParams.FIRST_VISIT_TIMESTAMP));
+        assertTrue(firstVisitTimeStamp > 0);
+        assertTrue((System.currentTimeMillis() - firstVisitTimeStamp) < 1000);
+        Tracker tracker1 = createTracker();
+        assertEquals(firstVisitTimeStamp, Long.parseLong(tracker1.getDefaultTrackMe().get(QueryParams.FIRST_VISIT_TIMESTAMP)));
+
+        tracker.trackEvent("TestCategory", "TestAction");
+        tracker1.trackEvent("TestCategory", "TestAction");
+        QueryHashMap<String, String> queryParams = parseEventUrl(tracker.getLastEvent());
+        assertEquals(firstVisitTimeStamp, Long.parseLong(queryParams.get(QueryParams.FIRST_VISIT_TIMESTAMP)));
+        queryParams = parseEventUrl(tracker1.getLastEvent());
+        assertEquals(firstVisitTimeStamp, Long.parseLong(queryParams.get(QueryParams.FIRST_VISIT_TIMESTAMP)));
+    }
+
     private static class QueryHashMap<String, V> extends HashMap<String, V> {
 
         private QueryHashMap() {

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -642,6 +642,35 @@ public class TrackerTest {
         assertEquals(2, Integer.parseInt(queryParams.get(QueryParams.TOTAL_NUMBER_OF_VISITS)));
     }
 
+    @Test
+    public void testPreviousVisit() throws Exception {
+        Piwik piwik = getPiwik();
+        assertEquals(-1, piwik.getSharedPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1));
+        Tracker tracker = createTracker();
+        long previousVisit = piwik.getSharedPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
+        assertTrue((System.currentTimeMillis() - previousVisit) < 100);
+        tracker.trackEvent("TestCategory", "TestAction");
+        QueryHashMap<String, String> queryParams = parseEventUrl(tracker.getLastEvent());
+        assertEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
+
+        tracker = createTracker();
+        tracker.trackEvent("TestCategory", "TestAction");
+        queryParams = parseEventUrl(tracker.getLastEvent());
+        assertEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
+
+        tracker = createTracker();
+        tracker.trackEvent("TestCategory", "TestAction");
+        queryParams = parseEventUrl(tracker.getLastEvent());
+        assertNotEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
+
+        previousVisit = piwik.getSharedPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
+
+        tracker = createTracker();
+        tracker.trackEvent("TestCategory", "TestAction");
+        queryParams = parseEventUrl(tracker.getLastEvent());
+        assertEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
+    }
+
     private static class QueryHashMap<String, V> extends HashMap<String, V> {
 
         private QueryHashMap() {

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -607,7 +607,6 @@ public class TrackerTest {
         Tracker tracker = createTracker();
         long firstVisitTimeStamp = Long.parseLong(tracker.getDefaultTrackMe().get(QueryParams.FIRST_VISIT_TIMESTAMP));
         assertTrue(firstVisitTimeStamp > 0);
-        assertTrue((System.currentTimeMillis() - firstVisitTimeStamp) < 1000);
         Tracker tracker1 = createTracker();
         assertEquals(firstVisitTimeStamp, Long.parseLong(tracker1.getDefaultTrackMe().get(QueryParams.FIRST_VISIT_TIMESTAMP)));
 

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -647,25 +647,29 @@ public class TrackerTest {
         Piwik piwik = getPiwik();
         // No timestamp yet
         assertEquals(-1, piwik.getSharedPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1));
+
         Tracker tracker = createTracker();
         long previousVisit = piwik.getSharedPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
-        assertTrue((System.currentTimeMillis() - previousVisit) < 100);
+        assertNotEquals(-1, previousVisit);
         tracker.trackEvent("TestCategory", "TestAction");
         QueryHashMap<String, String> queryParams = parseEventUrl(tracker.getLastEvent());
-        // Timestamp transmitted
+        // First transmission, timestamp is of this visit
         assertEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
+        Thread.sleep(2);
 
         tracker = createTracker();
         tracker.trackEvent("TestCategory", "TestAction");
         queryParams = parseEventUrl(tracker.getLastEvent());
         // Transmitted timestamp is the one from the last visit
         assertEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
+        Thread.sleep(2);
 
         tracker = createTracker();
         tracker.trackEvent("TestCategory", "TestAction");
         queryParams = parseEventUrl(tracker.getLastEvent());
         // Now the timestamp changed as this is the 3rd visit.
         assertNotEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
+        Thread.sleep(2);
 
         previousVisit = piwik.getSharedPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
 

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -645,22 +645,26 @@ public class TrackerTest {
     @Test
     public void testPreviousVisit() throws Exception {
         Piwik piwik = getPiwik();
+        // No timestamp yet
         assertEquals(-1, piwik.getSharedPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1));
         Tracker tracker = createTracker();
         long previousVisit = piwik.getSharedPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
         assertTrue((System.currentTimeMillis() - previousVisit) < 100);
         tracker.trackEvent("TestCategory", "TestAction");
         QueryHashMap<String, String> queryParams = parseEventUrl(tracker.getLastEvent());
+        // Timestamp transmitted
         assertEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
 
         tracker = createTracker();
         tracker.trackEvent("TestCategory", "TestAction");
         queryParams = parseEventUrl(tracker.getLastEvent());
+        // Transmitted timestamp is the one from the last visit
         assertEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
 
         tracker = createTracker();
         tracker.trackEvent("TestCategory", "TestAction");
         queryParams = parseEventUrl(tracker.getLastEvent());
+        // Now the timestamp changed as this is the 3rd visit.
         assertNotEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
 
         previousVisit = piwik.getSharedPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
@@ -668,6 +672,7 @@ public class TrackerTest {
         tracker = createTracker();
         tracker.trackEvent("TestCategory", "TestAction");
         queryParams = parseEventUrl(tracker.getLastEvent());
+        // Just make sure the timestamp in the 4th visit is from the 3rd visit
         assertEquals(previousVisit, Long.parseLong(queryParams.get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
     }
 


### PR DESCRIPTION
This PR addresses #18 by implementing the following parameters:

* "_idvc" aka Total-Visit-Count
* "_viewts" aka Previous-Visit-Timestamp
* "_idts" aka First-Visit-Timestamp

The Visitors -> Engangement page should now be correctly populated.
Segmentation for returning visitors should now also work.

Notes:
* The parameters are initialized/updated on Tracker creation not on first track. This prevents concurrence issues and deals with the fact that each Tracker has it's own visit session.
* The visit count is modified even when the user has chosen to opt-out. If he opts in at a later point in time, accurate values are transmitted.
* This PR increases the min API to 10 (Gingerbread 2.3.3+) to make use of SharedPreferences.apply() which improves performance, and in regards to #14.
* Similar to other one-time parameters these too are only transmitted on the first query per visit to conserve bandwidth.



