### PR TITLE
Feature: Smart dispatch

### DIFF
--- a/demo_app/src/main/java/com/piwik/demo/DemoApp.java
+++ b/demo_app/src/main/java/com/piwik/demo/DemoApp.java
@@ -16,15 +16,6 @@ public class DemoApp extends PiwikApplication {
         return "http://beacons.testing.piwik.pro/piwik.php";
     }
 
-    /**
-     * AuthToken is deprecated in Piwik >= 2.8.0 due to security reasons.
-     * @return token or null
-     */
-    @Override
-    public String getAuthToken() {
-        return null;
-    }
-
     @Override
     public Integer getSiteId() {
         return 4;

--- a/piwik_sdk/src/main/java/org/piwik/sdk/PiwikApplication.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/PiwikApplication.java
@@ -8,6 +8,7 @@
 package org.piwik.sdk;
 
 import android.app.Application;
+import android.os.Build;
 
 import java.net.MalformedURLException;
 
@@ -37,14 +38,29 @@ public abstract class PiwikApplication extends Application {
 
     /**
      * The URL of your remote Piwik server.
-     *
      */
     public abstract String getTrackerUrl();
 
     /**
      * The siteID you specified for this application in Piwik.
-     *
      */
     public abstract Integer getSiteId();
+
+
+    @Override
+    public void onLowMemory() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH && mPiwikTracker != null) {
+            mPiwikTracker.dispatch();
+        }
+        super.onLowMemory();
+    }
+
+    @Override
+    public void onTrimMemory(int level) {
+        if ((level == TRIM_MEMORY_UI_HIDDEN || level == TRIM_MEMORY_COMPLETE) && mPiwikTracker != null) {
+            mPiwikTracker.dispatch();
+        }
+        super.onTrimMemory(level);
+    }
 
 }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/PiwikApplication.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/PiwikApplication.java
@@ -19,56 +19,32 @@ public abstract class PiwikApplication extends Application {
     }
 
     /**
-     * Gives you a persisted Tracker object.
-     * <p/>
-     * The returned Tracker is not threadsafe at the moment.
-     * For use in threads create yourself a new tracker, see {@link #newTracker()}
+     * Gives you an all purpose thread-safe persisted Tracker object.
      *
      * @return a shared Tracker
      */
     public synchronized Tracker getTracker() {
         if (mPiwikTracker == null) {
-            mPiwikTracker = newTracker();
+            try {
+                mPiwikTracker = getPiwik().newTracker(getTrackerUrl(), getSiteId());
+            } catch (MalformedURLException e) {
+                e.printStackTrace();
+                throw new RuntimeException("Tracker URL was malformed.");
+            }
         }
         return mPiwikTracker;
     }
 
     /**
-     * Creates a new Tracker instance.
-     *
-     * @return a new Tracker, just for you.
-     */
-    public Tracker newTracker() {
-        try {
-            return getPiwik().newTracker(getTrackerUrl(), getSiteId(), getAuthToken());
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-            throw new RuntimeException("Tracker URL was malformed.");
-        }
-    }
-
-    /**
      * The URL of your remote Piwik server.
      *
-     * @return
      */
     public abstract String getTrackerUrl();
 
     /**
      * The siteID you specified for this application in Piwik.
      *
-     * @return
      */
     public abstract Integer getSiteId();
-
-
-    /**
-     * @deprecated An authoken from the Piwik server that allows more advanced features.
-     * It is encouraged that you do not use this within your app as the token can't be stored securely.
-     */
-    @Deprecated
-    public String getAuthToken() {
-        return null;
-    }
 
 }

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -72,17 +72,6 @@ public class TrackerTest {
     }
 
     @Test
-    public void testPiwikApplicationNewTracker() throws Exception {
-        PiwikApplication piwikApplication = (PiwikApplication) Robolectric.application;
-        assertEquals(piwikApplication.getTracker(), piwikApplication.getTracker());
-        assertEquals(piwikApplication.getTracker(), piwikApplication.newTracker());
-        Tracker manual = Piwik.getInstance(Robolectric.application).newTracker(piwikApplication.getTrackerUrl(), piwikApplication.getSiteId());
-        Tracker simplified = piwikApplication.newTracker();
-        assertEquals(manual.getAPIUrl(), simplified.getAPIUrl());
-        assertEquals(manual.getSiteId(), simplified.getSiteId());
-    }
-
-    @Test
     public void testPiwikApplicationgetPiwik() throws Exception {
         PiwikApplication piwikApplication = (PiwikApplication) Robolectric.application;
         assertEquals(piwikApplication.getPiwik(), Piwik.getInstance(piwikApplication));


### PR DESCRIPTION
From the Piwik application object we can get callbacks for memory events:
* Dispatch queued events when the app UI goes into the background (e.g. user is done with the app and presses the home button)
* Dispatch queued events when the app is running the risk of being killed to free memory. This makes sure that queued events are not lost and by emptying the queue we also free memory. Win-Win :smile: 

Side note:
* As Tracker is now threadsafe the Piwik application class was cleaned up a bit. We don't want to advertise using authToken and the develoepr should be encouraged to reuse the Tracker object.