### PR TITLE
More accurate visit values

### DIFF
--- a/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -26,6 +26,7 @@ public class Piwik {
 
     private static Piwik sInstance;
     private boolean mDebug = BuildConfig.DEBUG;
+    private final SharedPreferences mSharedPreferences;
 
     public static synchronized Piwik getInstance(Context context) {
         if (sInstance == null)
@@ -35,6 +36,7 @@ public class Piwik {
 
     private Piwik(Context context) {
         mContext = context.getApplicationContext();
+        mSharedPreferences = getContext().getSharedPreferences(PREFERENCE_FILE_NAME, Context.MODE_PRIVATE);
         mOptOut = getSharedPreferences().getBoolean(PREFERENCE_KEY_OPTOUT, false);
     }
 
@@ -118,6 +120,6 @@ public class Piwik {
      * @return Piwik's SharedPreferences instance
      */
     public SharedPreferences getSharedPreferences() {
-        return getContext().getSharedPreferences(PREFERENCE_FILE_NAME, Context.MODE_PRIVATE);
+        return mSharedPreferences;
     }
 }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/TrackMe.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/TrackMe.java
@@ -82,6 +82,10 @@ public class TrackMe {
         return trySet(key, String.valueOf(value));
     }
 
+    public synchronized TrackMe trySet(@NonNull QueryParams key, long value) {
+        return trySet(key, String.valueOf(value));
+    }
+
     /**
      * Only sets the value if it doesn't exist.
      *

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -128,16 +128,8 @@ public class Tracker {
     }
 
     /**
-     * This TrackMe object is used by Piwik to transmit a set of initial values, which only get send once per visit by default.
-     * If you which to send different values, change them on this object before the first transmission.
-     * <p/>
-     * {@link org.piwik.sdk.QueryParams#SESSION_START}<br>
-     * {@link org.piwik.sdk.QueryParams#SCREEN_RESOLUTION}<br>
-     * {@link org.piwik.sdk.QueryParams#USER_AGENT}<br>
-     * {@link org.piwik.sdk.QueryParams#LANGUAGE}<br>
-     * {@link org.piwik.sdk.QueryParams#COUNTRY}<br>
-     * <p/>
-     * If you wish to change any of these values after the first transmission, just send another TrackMe object with the relevant parameters set.
+     * Piwik will use the content of this object to fill in missing values before any transmission.
+     * While you can modify it's values, you can also just set them in your {@link TrackMe} object as already set values will not be overwritten.
      *
      * @return the default TrackMe object
      */

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -113,21 +113,6 @@ public class Tracker {
         mDefaultTrackMe.set(QueryParams.LANGUAGE, DeviceHelper.getUserLanguage());
         mDefaultTrackMe.set(QueryParams.COUNTRY, DeviceHelper.getUserCountry());
         mDefaultTrackMe.set(QueryParams.VISITOR_ID, makeRandomVisitorId());
-
-        long firstVisitTime = getSharedPreferences().getLong(PREF_KEY_TRACKER_FIRSTVISIT, -1);
-        if (firstVisitTime == -1) {
-            firstVisitTime = System.currentTimeMillis();
-            getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_FIRSTVISIT, firstVisitTime).apply();
-        }
-        mDefaultTrackMe.set(QueryParams.FIRST_VISIT_TIMESTAMP, firstVisitTime);
-
-        int visitCount = getSharedPreferences().getInt(PREF_KEY_TRACKER_VISITCOUNT, 0);
-        getSharedPreferences().edit().putInt(PREF_KEY_TRACKER_VISITCOUNT, ++visitCount).apply();
-        mDefaultTrackMe.set(QueryParams.TOTAL_NUMBER_OF_VISITS, visitCount);
-
-        long previousVisit = getSharedPreferences().getLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis());
-        mDefaultTrackMe.set(QueryParams.PREVIOUS_VISIT_TIMESTAMP, previousVisit);
-        getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis()).apply();
     }
 
     public Piwik getPiwik() {
@@ -622,9 +607,38 @@ public class Tracker {
             mSessionStartTime = System.currentTimeMillis();
         }
         // First track in this session, tell Piwik all we can offer by default
-        if (newSession)
-            injectInitialParams(trackMe);
+        if (newSession) {
+            long firstVisitTime;
+            int visitCount;
+            long previousVisit;
 
+            // synchronizing this because there could be Trackers on different threads
+            synchronized (getSharedPreferences()) {
+                visitCount = 1 + getSharedPreferences().getInt(PREF_KEY_TRACKER_VISITCOUNT, 0);
+                getSharedPreferences().edit().putInt(PREF_KEY_TRACKER_VISITCOUNT, visitCount).apply();
+            }
+
+            synchronized (getSharedPreferences()) {
+                firstVisitTime = getSharedPreferences().getLong(PREF_KEY_TRACKER_FIRSTVISIT, -1);
+                if (firstVisitTime == -1) {
+                    firstVisitTime = System.currentTimeMillis();
+                    getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_FIRSTVISIT, firstVisitTime).apply();
+                }
+            }
+
+            synchronized (getSharedPreferences()) {
+                previousVisit = getSharedPreferences().getLong(PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
+                getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis()).apply();
+            }
+
+            // trySet because the developer could have modded these after creating the Tracker
+            mDefaultTrackMe.trySet(QueryParams.FIRST_VISIT_TIMESTAMP, firstVisitTime);
+            mDefaultTrackMe.trySet(QueryParams.TOTAL_NUMBER_OF_VISITS, visitCount);
+            if (previousVisit != -1)
+                mDefaultTrackMe.trySet(QueryParams.PREVIOUS_VISIT_TIMESTAMP, previousVisit);
+
+            injectInitialParams(trackMe);
+        }
         injectBaseParams(trackMe);
     }
 

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -634,7 +634,7 @@ public class TrackerTest {
 
     @Test
     public void testVisitCountMultipleThreads() throws Exception {
-        int threadCount = 10000;
+        int threadCount = 1000;
         final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
         for (int i = 0; i < threadCount; i++) {
             new Thread(new Runnable() {


### PR DESCRIPTION
The "visit frequency", "first visit" and "previous visit" values now get updated on the first track(...) call instead of on Tracker creation.
I think this is the more expected behavior, while we can presetup a Tracker with userid/url/siteid one would expect the visit values to only change when something is actually tracked, i.e. the visit is happening.

Notes:
* I added 3 syncronize blocks around each value change to prevent concurrency issues from causing incorrect values. While preferences are threadsafe, read+updating values is not atomic.
* PREF_KEY_TRACKER_VISITCOUNT requires the syncronization as otherwise the counter loose increments.
* The other keys don't have such grave sideeffects when concurrency issues occur. Mainly a change in time by a few miliseconds depending on which threads was faster. We could wager to remove their syncronizing block but as this just happens once per visit session, it wouldn't really improve performance.
