### PR TITLE
Bugfixes: Visit time values & Race-condition on session start

### DIFF
--- a/piwik_sdk/src/main/java/org/piwik/sdk/Dispatcher.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Dispatcher.java
@@ -72,6 +72,10 @@ public class Dispatcher {
         mAuthToken = authToken;
     }
 
+    /**
+     * Connection timeout in miliseconds
+     * @return
+     */
     public int getTimeOut() {
         return mTimeOut;
     }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Dispatcher.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Dispatcher.java
@@ -23,7 +23,6 @@ import org.apache.http.protocol.HTTP;
 import org.json.JSONObject;
 import org.piwik.sdk.tools.Logy;
 
-import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -74,6 +73,7 @@ public class Dispatcher {
 
     /**
      * Connection timeout in miliseconds
+     *
      * @return
      */
     public int getTimeOut() {
@@ -206,7 +206,7 @@ public class Dispatcher {
                 int statusCode = response.getStatusLine().getStatusCode();
                 Logy.d(LOGGER_TAG, String.format("status code %s", statusCode));
                 return statusCode == HttpStatus.SC_NO_CONTENT || statusCode == HttpStatus.SC_OK;
-            } catch (IOException e) {
+            } catch (Exception e) {
                 Logy.w(LOGGER_TAG, "Cannot send request", e);
             }
         }

--- a/piwik_sdk/src/main/java/org/piwik/sdk/QueryParams.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/QueryParams.java
@@ -84,12 +84,12 @@ public enum QueryParams {
      */
     TOTAL_NUMBER_OF_VISITS("_idvc"),
     /**
-     * The UNIX timestamp of this visitor's previous visit.<p>
+     * The UNIX timestamp of this visitor's previous visit (seconds since Jan 01 1970. (UTC)).<p>
      * This parameter is used to populate the report Visitors > Engagement > Visits by days since last visit.
      */
     PREVIOUS_VISIT_TIMESTAMP("_viewts"),
     /**
-     * The UNIX timestamp of this visitor's first visit.<p>
+     * The UNIX timestamp of this visitor's first visit (seconds since Jan 01 1970. (UTC)).<p>
      * This could be set to the date where the user first started using your software/app, or when he/she created an account.
      * This parameter is used to populate the Goals > Days to Conversion report.
      */

--- a/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik_sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -613,14 +613,14 @@ public class Tracker {
             synchronized (getSharedPreferences()) {
                 firstVisitTime = getSharedPreferences().getLong(PREF_KEY_TRACKER_FIRSTVISIT, -1);
                 if (firstVisitTime == -1) {
-                    firstVisitTime = System.currentTimeMillis();
+                    firstVisitTime = System.currentTimeMillis() / 1000;
                     getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_FIRSTVISIT, firstVisitTime).apply();
                 }
             }
 
             synchronized (getSharedPreferences()) {
                 previousVisit = getSharedPreferences().getLong(PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
-                getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis()).apply();
+                getSharedPreferences().edit().putLong(PREF_KEY_TRACKER_PREVIOUSVISIT, System.currentTimeMillis() / 1000).apply();
             }
 
             // trySet because the developer could have modded these after creating the Tracker

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TestDispatcher.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TestDispatcher.java
@@ -54,6 +54,31 @@ public class TestDispatcher {
         Piwik.getInstance(Robolectric.application).setDebug(false);
     }
 
+    @Test
+    public void testSessionStartRaceCondition() throws Exception {
+        for (int i = 0; i < 50; i++) {
+            getPiwik().setDryRun(true);
+            final Tracker tracker = createTracker();
+            tracker.setDispatchInterval(0);
+            final int threadCount = 10;
+            final int queryCount = 3;
+            final List<String> createdEvents = Collections.synchronizedList(new ArrayList<String>());
+            launchTestThreads(tracker, threadCount, queryCount, createdEvents);
+            checkForMIAs(threadCount * queryCount, createdEvents, tracker.getDispatcher().getDryRunOutput());
+            List<String> output = getFlattenedQueries(tracker.getDispatcher().getDryRunOutput());
+            for (String out : output) {
+                if (output.indexOf(out) == 0) {
+                    assertTrue(out.contains("lang"));
+                    assertTrue(out.contains("_idts"));
+                    assertTrue(out.contains("new_visit"));
+                } else {
+                    assertFalse(out.contains("lang"));
+                    assertFalse(out.contains("_idts"));
+                    assertFalse(out.contains("new_visit"));
+                }
+            }
+        }
+    }
 
     @Test
     public void testMultiThreadDispatch() throws Exception {
@@ -175,7 +200,11 @@ public class TestDispatcher {
                                     .set(QueryParams.EVENT_CATEGORY, UUID.randomUUID().toString())
                                     .set(QueryParams.EVENT_NAME, UUID.randomUUID().toString())
                                     .set(QueryParams.EVENT_VALUE, j);
+
+                            long start = System.currentTimeMillis();
                             tracker.track(trackMe);
+                            long stop = System.currentTimeMillis();
+                            Log.v("track(TrackMe)", "track(...) build-time:" + (stop - start) + "ms");
                             createdQueries.add(tracker.getAPIUrl().toString() + trackMe.build());
                         }
                     } catch (Exception e) {

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TestDispatcher.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TestDispatcher.java
@@ -57,6 +57,7 @@ public class TestDispatcher {
     @Test
     public void testSessionStartRaceCondition() throws Exception {
         for (int i = 0; i < 50; i++) {
+            Log.d("RaceConditionTest",  (50 - i) + " race-condition tests to go.");
             getPiwik().setDryRun(true);
             final Tracker tracker = createTracker();
             tracker.setDispatchInterval(0);
@@ -201,10 +202,7 @@ public class TestDispatcher {
                                     .set(QueryParams.EVENT_NAME, UUID.randomUUID().toString())
                                     .set(QueryParams.EVENT_VALUE, j);
 
-                            long start = System.currentTimeMillis();
                             tracker.track(trackMe);
-                            long stop = System.currentTimeMillis();
-                            Log.v("track(TrackMe)", "track(...) build-time:" + (stop - start) + "ms");
                             createdQueries.add(tracker.getAPIUrl().toString() + trackMe.build());
                         }
                     } catch (Exception e) {

--- a/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik_sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -121,16 +121,16 @@ public class TrackerTest {
         assertEquals(tracker.getApplicationDomain(), "test.com");
         assertEquals(tracker.getApplicationBaseURL(), "http://test.com");
         TrackMe trackMe = new TrackMe();
-        tracker.doInjections(trackMe);
+        tracker.track(trackMe);
         assertEquals("http://test.com/", trackMe.get(QueryParams.URL_PATH));
 
         trackMe.set(QueryParams.URL_PATH, "me");
-        tracker.doInjections(trackMe);
+        tracker.track(trackMe);
         assertEquals("http://test.com/me", trackMe.get(QueryParams.URL_PATH));
 
         // override protocol
         trackMe.set(QueryParams.URL_PATH, "https://my.com/secure");
-        tracker.doInjections(trackMe);
+        tracker.track(trackMe);
         assertEquals("https://my.com/secure", trackMe.get(QueryParams.URL_PATH));
     }
 
@@ -204,7 +204,7 @@ public class TrackerTest {
         tracker.setVisitorId(visitorId);
         assertEquals(visitorId, tracker.getVisitorId());
         TrackMe trackMe = new TrackMe();
-        tracker.doInjections(trackMe);
+        tracker.track(trackMe);
         assertTrue(trackMe.build().contains("_id=" + visitorId));
     }
 
@@ -232,7 +232,7 @@ public class TrackerTest {
     public void testGetResolution() throws Exception {
         Tracker tracker = createTracker();
         TrackMe trackMe = new TrackMe();
-        tracker.doInjections(trackMe);
+        tracker.track(trackMe);
         assertTrue(trackMe.build().contains("res=480x800"));
     }
 
@@ -267,7 +267,7 @@ public class TrackerTest {
     public void testSetNewSession() throws Exception {
         Tracker tracker = createTracker();
         TrackMe trackMe = new TrackMe();
-        tracker.doInjections(trackMe);
+        tracker.track(trackMe);
         assertTrue(trackMe.build().contains("new_visit=1"));
 
         tracker.trackScreenView("");
@@ -321,14 +321,14 @@ public class TrackerTest {
 
         tracker.setSessionTimeout(10000);
         tracker.trackScreenView("test");
-        assertFalse(tracker.isSessionExpired());
+        assertFalse(tracker.tryNewSession());
 
         tracker.setSessionTimeout(0);
         Thread.sleep(1, 0);
-        assertTrue(tracker.isSessionExpired());
+        assertTrue(tracker.tryNewSession());
 
         tracker.setSessionTimeout(10000);
-        assertFalse(tracker.isSessionExpired());
+        assertFalse(tracker.tryNewSession());
 
     }
 
@@ -549,7 +549,7 @@ public class TrackerTest {
         for (String path : paths) {
             TrackMe trackMe = new TrackMe();
             trackMe.set(QueryParams.URL_PATH, path);
-            tracker.doInjections(trackMe);
+            tracker.track(trackMe);
             assertEquals("http://org.piwik.sdk.test/", trackMe.get(QueryParams.URL_PATH));
         }
     }
@@ -578,21 +578,21 @@ public class TrackerTest {
         // Default system user agent
         Tracker tracker = createTracker();
         TrackMe trackMe = new TrackMe();
-        tracker.doInjections(trackMe);
+        tracker.track(trackMe);
         assertEquals(defaultUserAgent, trackMe.get(QueryParams.USER_AGENT));
 
         // Custom developer specified useragent
         tracker = createTracker();
         trackMe = new TrackMe();
         trackMe.set(QueryParams.USER_AGENT, customUserAgent);
-        tracker.doInjections(trackMe);
+        tracker.track(trackMe);
         assertEquals(customUserAgent, trackMe.get(QueryParams.USER_AGENT));
 
         // Modifying default TrackMe, no USER_AGENT
         tracker = createTracker();
         trackMe = new TrackMe();
         tracker.getDefaultTrackMe().set(QueryParams.USER_AGENT, null);
-        tracker.doInjections(trackMe);
+        tracker.track(trackMe);
         assertEquals(null, trackMe.get(QueryParams.USER_AGENT));
     }
 


### PR DESCRIPTION
This PR fixes two major issues.

The first issue is that during my previous implementation of previous-visit and first-visit i overlooked that Piwik expects the timestamps in seconds (unix timestamp is always in seconds, i overlooked that) and used **System.currentTimeMillis()** ... *sigh* This is fixed now by just dividing the value through 1000.
We now also have tests for this.

The second issue is a race-condition on session start.
The first thread that tracks something will do the session-start initialization, i.e. information that only needs to be transmitted once. While loading/inserting these values into the TrackMe request, it is possible that a second thread overtakes the first one and puts his transmission (missing the initial transmission infos) into the Dispatcher queue before the first thread does so.
I've made changes to fix this. A CountDownLatch now prevents other threads from dispatching events until the first thread put his "new-session" event into the Dispatcher queue.
We now also have tests for this.