### PR TITLE
Replacing depcrated org.apache.http classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ jdk: oraclejdk7
 
 android:
   components:
-    - build-tools-22.0.1
-    - android-22
+    - tools
+    - build-tools-23.0.2
+    - android-23
     - extra-android-support
     - extra-android-m2repository
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.3.1'
         // NOTE: Do not place your application dependencies here; they belong

--- a/exampleapp/build.gradle
+++ b/exampleapp/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.piwik.demo"
         minSdkVersion 11
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -19,6 +19,6 @@ android {
 
 dependencies {
     compile project(":piwik-sdk")
-    compile 'com.android.support:appcompat-v7:22.2.1'
-    compile 'com.android.support:support-v4:22.2.1'
+    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:support-v4:23.1.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip

--- a/piwik-sdk/build.gradle
+++ b/piwik-sdk/build.gradle
@@ -32,12 +32,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.2'
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode myVersionCode
         versionName myVersionName
     }
@@ -47,7 +47,7 @@ dependencies {
     repositories {
         mavenCentral()
     }
-    compile 'com.android.support:support-annotations:22.2.1'
+    compile 'com.android.support:support-annotations:23.1.1'
     // Espresso
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.0')
     androidTestCompile('com.android.support.test:testing-support-lib:0.1')

--- a/piwik-sdk/src/main/java/org/piwik/sdk/TrackMe.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/TrackMe.java
@@ -9,6 +9,8 @@ package org.piwik.sdk;
 
 import android.support.annotation.NonNull;
 
+import org.piwik.sdk.dispatcher.Dispatcher;
+
 import java.util.HashMap;
 
 /**

--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -15,6 +15,7 @@ import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.piwik.sdk.dispatcher.Dispatcher;
 import org.piwik.sdk.ecommerce.EcommerceItems;
 import org.piwik.sdk.tools.Checksum;
 import org.piwik.sdk.tools.CurrencyFormatter;

--- a/piwik-sdk/src/main/java/org/piwik/sdk/TrackerBulkURLWrapper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/TrackerBulkURLWrapper.java
@@ -7,6 +7,8 @@
 
 package org.piwik.sdk;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import org.json.JSONArray;
@@ -14,6 +16,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.piwik.sdk.tools.Logy;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
@@ -28,14 +31,14 @@ public class TrackerBulkURLWrapper {
     private final String mAuthtoken;
     private final List<String> mEvents;
 
-    public TrackerBulkURLWrapper(final URL apiUrl, final List<String> events, final String authToken) {
+    public TrackerBulkURLWrapper(@NonNull final URL apiUrl, @NonNull final List<String> events, @Nullable final String authToken) {
         mApiUrl = apiUrl;
         mAuthtoken = authToken;
         mPages = (int) Math.ceil(events.size() * 1.0 / EVENTS_PER_PAGE);
         mEvents = events;
     }
 
-    protected static int getEventsPerPage(){
+    protected static int getEventsPerPage() {
         return EVENTS_PER_PAGE;
     }
 
@@ -65,6 +68,7 @@ public class TrackerBulkURLWrapper {
         };
     }
 
+    @NonNull
     public URL getApiUrl() {
         return mApiUrl;
     }
@@ -78,6 +82,7 @@ public class TrackerBulkURLWrapper {
      *
      * @return json object
      */
+    @Nullable
     public JSONObject getEvents(Page page) {
         if (page == null || page.isEmpty()) {
             return null;
@@ -85,7 +90,7 @@ public class TrackerBulkURLWrapper {
 
         List<String> pageElements = mEvents.subList(page.fromIndex, page.toIndex);
 
-        if(pageElements.size() == 0){
+        if (pageElements.size() == 0) {
             Logy.w(LOGGER_TAG, "Empty page");
             return null;
         }
@@ -108,14 +113,19 @@ public class TrackerBulkURLWrapper {
     /**
      * @param page Page object
      * @return tracked url. For example
-     *  "http://domain.com/piwik.php?idsite=1&url=http://a.org&action_name=Test bulk log Pageview&rec=1"
+     * "http://domain.com/piwik.php?idsite=1&url=http://a.org&action_name=Test bulk log Pageview&rec=1"
      */
-    public String getEventUrl(Page page) {
-        if (page == null || page.isEmpty()) {
+    @Nullable
+    public URL getEventUrl(Page page) {
+        if (page == null || page.isEmpty())
             return null;
-        }
 
-        return getApiUrl().toString() + mEvents.get(page.fromIndex);
+        try {
+            return new URL(getApiUrl().toString() + mEvents.get(page.fromIndex));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public final class Page {

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
@@ -75,10 +75,19 @@ public class Dispatcher {
         return mTimeOut;
     }
 
+    /**
+     * Timeout when trying to establish connection and when trying to read a response.
+     *
+     * @param timeOut timeout in milliseconds
+     */
     public void setTimeOut(int timeOut) {
         mTimeOut = timeOut;
     }
 
+    /**
+     * Packets are collected and dispatched in batches, this intervals sets the pause between batches.
+     * @param dispatchInterval in milliseconds
+     */
     public void setDispatchInterval(long dispatchInterval) {
         mDispatchInterval = dispatchInterval;
         if (mDispatchInterval != -1)
@@ -168,7 +177,7 @@ public class Dispatcher {
 
     @VisibleForTesting
     public boolean dispatch(@NonNull Packet packet) {
-         // Some error checking
+        // Some error checking
         if (packet.getTargetURL() == null)
             return false;
         if (packet.getJSONObject() != null && packet.getJSONObject().length() == 0)
@@ -188,7 +197,7 @@ public class Dispatcher {
             urlConnection.setConnectTimeout(mTimeOut);
             urlConnection.setReadTimeout(mTimeOut);
 
-            // IF there is there is json data we want to do a post
+            // IF there is json data we want to do a post
             if (packet.getJSONObject() != null) {
                 // POST
                 urlConnection.setDoOutput(true); // Forces post

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
@@ -5,26 +5,21 @@
  * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
  */
 
-package org.piwik.sdk;
+package org.piwik.sdk.dispatcher;
 
 import android.os.Process;
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.message.BasicHeader;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.protocol.HTTP;
 import org.json.JSONObject;
+import org.piwik.sdk.Piwik;
+import org.piwik.sdk.TrackerBulkURLWrapper;
 import org.piwik.sdk.tools.Logy;
 
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
-import java.net.URISyntaxException;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -58,7 +53,7 @@ public class Dispatcher {
     private final URL mApiUrl;
     private final String mAuthToken;
 
-    private List<HttpRequestBase> mDryRunOutput = Collections.synchronizedList(new ArrayList<HttpRequestBase>());
+    private List<Packet> mDryRunOutput = Collections.synchronizedList(new ArrayList<Packet>());
 
     private volatile int mTimeOut = 5 * 1000; // 5s
     private volatile boolean mRunning = false;
@@ -146,10 +141,16 @@ public class Dispatcher {
 
                     // use doGET when only event on current page
                     if (page.elementsCount() > 1) {
-                        if (doPost(wrapper.getApiUrl(), wrapper.getEvents(page)))
+                        JSONObject eventData = wrapper.getEvents(page);
+                        if (eventData == null)
+                            continue;
+                        if (dispatch(new Packet(wrapper.getApiUrl(), eventData)))
                             count += page.elementsCount();
                     } else {
-                        if (doGet(wrapper.getEventUrl(page)))
+                        URL targetURL = wrapper.getEventUrl(page);
+                        if (targetURL == null)
+                            continue;
+                        if (dispatch(new Packet(targetURL)))
                             count += 1;
                     }
                 }
@@ -165,52 +166,50 @@ public class Dispatcher {
         }
     };
 
-    protected boolean doGet(String trackingEndPointUrl) {
-        if (trackingEndPointUrl == null)
+    @VisibleForTesting
+    public boolean dispatch(@NonNull Packet packet) {
+         // Some error checking
+        if (packet.getTargetURL() == null)
             return false;
-        HttpGet get = new HttpGet(trackingEndPointUrl);
-        return doRequest(get);
-    }
-
-    protected boolean doPost(URL url, JSONObject json) {
-        if (url == null || json == null)
+        if (packet.getJSONObject() != null && packet.getJSONObject().length() == 0)
             return false;
-
-        String jsonBody = json.toString();
-        try {
-            HttpPost post = new HttpPost(url.toURI());
-            StringEntity se = new StringEntity(jsonBody);
-            se.setContentType(new BasicHeader(HTTP.CONTENT_TYPE, "application/json"));
-            post.setEntity(se);
-
-            return doRequest(post);
-        } catch (URISyntaxException e) {
-            Logy.w(LOGGER_TAG, String.format("URI Syntax Error %s", url.toString()), e);
-        } catch (UnsupportedEncodingException e) {
-            Logy.w(LOGGER_TAG, String.format("Unsupported Encoding %s", jsonBody), e);
-        }
-        return false;
-    }
-
-    private boolean doRequest(HttpRequestBase requestBase) {
-        HttpClient client = new DefaultHttpClient();
-        HttpConnectionParams.setConnectionTimeout(client.getParams(), mTimeOut);
-        HttpResponse response;
 
         if (mPiwik.isDryRun()) {
             Logy.d(LOGGER_TAG, "DryRun, stored HttpRequest, now " + mDryRunOutput.size());
-            mDryRunOutput.add(requestBase);
-        } else {
-            if (!mDryRunOutput.isEmpty())
-                mDryRunOutput.clear();
-            try {
-                response = client.execute(requestBase);
-                int statusCode = response.getStatusLine().getStatusCode();
-                Logy.d(LOGGER_TAG, String.format("status code %s", statusCode));
-                return statusCode == HttpStatus.SC_NO_CONTENT || statusCode == HttpStatus.SC_OK;
-            } catch (Exception e) {
-                Logy.w(LOGGER_TAG, "Cannot send request", e);
+            mDryRunOutput.add(packet);
+            return true;
+        }
+
+        if (!mDryRunOutput.isEmpty())
+            mDryRunOutput.clear();
+
+        try {
+            HttpURLConnection urlConnection = (HttpURLConnection) packet.getTargetURL().openConnection();
+            urlConnection.setConnectTimeout(mTimeOut);
+            urlConnection.setReadTimeout(mTimeOut);
+
+            // IF there is there is json data we want to do a post
+            if (packet.getJSONObject() != null) {
+                // POST
+                urlConnection.setDoOutput(true); // Forces post
+                urlConnection.setRequestProperty("Content-Type", "application/json");
+                urlConnection.setRequestProperty("charset", "utf-8");
+
+                BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(urlConnection.getOutputStream(), "UTF-8"));
+                writer.write(packet.getJSONObject().toString());
+                writer.flush();
+                writer.close();
+            } else {
+                // GET
+                urlConnection.setDoOutput(false); // Defaults to false, but for readability
             }
+
+            int statusCode = urlConnection.getResponseCode();
+            Logy.d(LOGGER_TAG, String.format("status code %s", statusCode));
+            return statusCode == HttpURLConnection.HTTP_NO_CONTENT || statusCode == HttpURLConnection.HTTP_OK;
+        } catch (Exception e) {
+            // Broad but an analytics app shouldn't impact it's host app.
+            Logy.w(LOGGER_TAG, "Cannot send request", e);
         }
         return false;
     }
@@ -251,7 +250,7 @@ public class Dispatcher {
         return sb.substring(0, sb.length() - 1);
     }
 
-    public List<HttpRequestBase> getDryRunOutput() {
+    public List<Packet> getDryRunOutput() {
         return mDryRunOutput;
     }
 

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Packet.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Packet.java
@@ -1,0 +1,49 @@
+/*
+ * Android SDK for Piwik
+ *
+ * @link https://github.com/piwik/piwik-android-sdk
+ * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ */
+package org.piwik.sdk.dispatcher;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import org.json.JSONObject;
+
+import java.net.URL;
+
+/**
+ * Data that can be send to the backend API via the Dispatcher
+ */
+@VisibleForTesting
+public class Packet {
+    private final URL mTargetURL;
+    private final JSONObject mJSONObject;
+    private final long mTimeStamp;
+
+    public Packet(@NonNull URL targetURL) {
+        this(targetURL, null);
+    }
+
+    public Packet(@NonNull URL targetURL, @Nullable JSONObject JSONObject) {
+        mTargetURL = targetURL;
+        mJSONObject = JSONObject;
+        mTimeStamp = System.currentTimeMillis();
+    }
+
+    @NonNull
+    public URL getTargetURL() {
+        return mTargetURL;
+    }
+
+    @Nullable
+    public JSONObject getJSONObject() {
+        return mJSONObject;
+    }
+
+    public long getTimeStamp() {
+        return mTimeStamp;
+    }
+}

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Packet.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Packet.java
@@ -23,10 +23,16 @@ public class Packet {
     private final JSONObject mJSONObject;
     private final long mTimeStamp;
 
+    /**
+     * Constructor for GET requests
+     */
     public Packet(@NonNull URL targetURL) {
         this(targetURL, null);
     }
 
+    /**
+     * Constructor for POST requests
+     */
     public Packet(@NonNull URL targetURL, @Nullable JSONObject JSONObject) {
         mTargetURL = targetURL;
         mJSONObject = JSONObject;
@@ -38,11 +44,17 @@ public class Packet {
         return mTargetURL;
     }
 
+    /**
+     * @return may be null if it is a GET request
+     */
     @Nullable
     public JSONObject getJSONObject() {
         return mJSONObject;
     }
 
+    /**
+     * A timestamp to use when replaying offline data
+     */
     public long getTimeStamp() {
         return mTimeStamp;
     }

--- a/piwik-sdk/src/main/java/org/piwik/sdk/tools/UrlHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/tools/UrlHelper.java
@@ -1,0 +1,67 @@
+/*
+ *
+ *  * Android SDK for Piwik
+ *  *
+ *  * @link https://github.com/piwik/piwik-android-sdk
+ *  * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ *
+ */
+
+package org.piwik.sdk.tools;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Pair;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
+
+/**
+ * Helps us with Urls.
+ */
+public class UrlHelper {
+    private static final String PARAMETER_SEPARATOR = "&";
+    private static final String NAME_VALUE_SEPARATOR = "=";
+
+    // Inspired by https://github.com/android/platform_external_apache-http/blob/master/src/org/apache/http/client/utils/URLEncodedUtils.java
+    // Helper due to Apache http deprecation
+
+    public static List<Pair<String, String>> parse(@NonNull final URI uri, @Nullable final String encoding) {
+        List<Pair<String, String>> result = Collections.emptyList();
+        final String query = uri.getRawQuery();
+        if (query != null && query.length() > 0) {
+            result = new ArrayList<>();
+            parse(result, new Scanner(query), encoding);
+        }
+        return result;
+    }
+
+    public static void parse(@NonNull final List<Pair<String, String>> parameters, @NonNull final Scanner scanner, @Nullable final String encoding) {
+        scanner.useDelimiter(PARAMETER_SEPARATOR);
+        while (scanner.hasNext()) {
+            final String[] nameValue = scanner.next().split(NAME_VALUE_SEPARATOR);
+            if (nameValue.length == 0 || nameValue.length > 2)
+                throw new IllegalArgumentException("bad parameter");
+
+            final String name = decode(nameValue[0], encoding);
+            String value = null;
+            if (nameValue.length == 2)
+                value = decode(nameValue[1], encoding);
+            parameters.add(new Pair<>(name, value));
+        }
+    }
+
+
+    private static String decode(@NonNull final String content, @Nullable final String encoding) {
+        try {
+            return URLDecoder.decode(content, encoding != null ? encoding : "UTF-8");
+        } catch (UnsupportedEncodingException problem) {
+            throw new IllegalArgumentException(problem);
+        }
+    }
+}

--- a/piwik-sdk/src/test/java/org/piwik/sdk/QuickTrackTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/QuickTrackTest.java
@@ -7,11 +7,12 @@
 
 package org.piwik.sdk;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
+import android.util.Pair;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.piwik.sdk.tools.UrlHelper;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
@@ -53,14 +54,11 @@ public class QuickTrackTest {
     }
 
     private static QueryHashMap<String, String> parseEventUrl(String url) throws Exception {
-        QueryHashMap<String, String> values = new QueryHashMap<String, String>();
-
-        List<NameValuePair> params = URLEncodedUtils.parse(new URI("http://localhost/" + url), "UTF-8");
-
-        for (NameValuePair param : params) {
-            values.put(param.getName(), param.getValue());
-        }
-
+        QueryHashMap<String, String> values = new QueryHashMap<>();
+        List<Pair<String, String>> params = UrlHelper.parse(new URI("http://localhost/" + url), "UTF-8");
+        
+        for (Pair<String, String> param : params)
+            values.put(param.first, param.second);
         return values;
     }
 

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerBulkURLWrapperTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerBulkURLWrapperTest.java
@@ -49,7 +49,7 @@ public class TrackerBulkURLWrapperTest {
         for (int i = 0; i < TrackerBulkURLWrapper.getEventsPerPage() * 2; i++) {
             events.add("eve" + i);
         }
-        TrackerBulkURLWrapper wrapper = new TrackerBulkURLWrapper(null, events, null);
+        TrackerBulkURLWrapper wrapper = new TrackerBulkURLWrapper(new URL("http://example.com/"), events, null);
 
         Iterator<TrackerBulkURLWrapper.Page> it = wrapper.iterator();
         assertTrue(it.hasNext());
@@ -99,6 +99,6 @@ public class TrackerBulkURLWrapperTest {
         TrackerBulkURLWrapper.Page page = wrapper.iterator().next();
         assertEquals(page.elementsCount(), 1);
         assertFalse(page.isEmpty());
-        assertEquals(wrapper.getEventUrl(page), "http://example.com/?eve20");
+        assertEquals(wrapper.getEventUrl(page), new URL("http://example.com/?eve20"));
     }
 }

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
@@ -554,6 +555,7 @@ public class TrackerTest {
     @Test
     public void testTrackEcommerceCartUpdate() throws Exception {
         Tracker tracker = createTracker();
+        Locale.setDefault(Locale.US);
         EcommerceItems items = new EcommerceItems();
         items.addItem("fake_sku", "fake_product", "fake_category", 200, 2);
         items.addItem("fake_sku_2", "fake_product_2", "fake_category_2", 400, 3);
@@ -576,6 +578,7 @@ public class TrackerTest {
     @Test
     public void testTrackEcommerceOrder() throws Exception {
         Tracker tracker = createTracker();
+        Locale.setDefault(Locale.US);
         EcommerceItems items = new EcommerceItems();
         items.addItem("fake_sku", "fake_product", "fake_category", 200, 2);
         items.addItem("fake_sku_2", "fake_product_2", "fake_category_2", 400, 3);

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -1,15 +1,15 @@
 package org.piwik.sdk;
 
 import android.app.Application;
+import android.util.Pair;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.piwik.sdk.ecommerce.EcommerceItems;
 import org.piwik.sdk.plugins.CustomDimensions;
+import org.piwik.sdk.tools.UrlHelper;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
@@ -873,15 +873,13 @@ public class TrackerTest {
         }
     }
 
-    @SuppressWarnings("deprecation")
     private static QueryHashMap<String, String> parseEventUrl(String url) throws Exception {
         QueryHashMap<String, String> values = new QueryHashMap<>();
 
-        List<NameValuePair> params = URLEncodedUtils.parse(new URI("http://localhost/" + url), "UTF-8");
+        List<Pair<String, String>> params = UrlHelper.parse(new URI("http://localhost/" + url), "UTF-8");
 
-        for (NameValuePair param : params) {
-            values.put(param.getName(), param.getValue());
-        }
+        for (Pair<String, String> param : params)
+            values.put(param.first, param.second);
 
         return values;
     }

--- a/piwik-sdk/src/test/java/org/piwik/sdk/ecommerce/EcommerceItemsTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/ecommerce/EcommerceItemsTest.java
@@ -5,6 +5,8 @@ import org.junit.runner.RunWith;
 import org.piwik.sdk.FullEnvTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Locale;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -20,6 +22,7 @@ public class EcommerceItemsTest {
 
     @Test
     public void testAddItems() throws Exception {
+        Locale.setDefault(Locale.US);
         EcommerceItems items = new EcommerceItems();
         items.addItem("fake_sku", "fake_product", "fake_category", 200, 2);
         items.addItem("fake_sku_2", "fake_product_2", "fake_category_2", 400, 3);
@@ -31,6 +34,7 @@ public class EcommerceItemsTest {
 
     @Test
     public void testRemoveItem() throws Exception {
+        Locale.setDefault(Locale.US);
         EcommerceItems items = new EcommerceItems();
         items.addItem("fake_sku", "fake_product", "fake_category", 200, 2);
         items.addItem("fake_sku_2", "fake_product_2", "fake_category_2", 400, 3);


### PR DESCRIPTION
This PR implements #61 (deprecation of http classes) , contributes towards #64 (v1.0 release) and adds preparation for #16 (offline mode).

* Updated gradle and build targetAPI to 23.
* Replaced all now missing classes. The base communication is now handled by ```HttpURLConnection```. Other classes have been replaced by either existing SDK classes or new helper classes.
* The new class ```Packet``` contains a unit of information that the ```Dispatcher``` sends to the backend. This replaces ```HttpRequestBase``` and will be helpful when we add code to deal with offline caching.
* I also did some light refactoring and added annotations to make non-null and null values more obvious.
* Also fixed some weird flaky test due to currency formating USA ".", Germany ","

First draft, unit tests pass, but still have to test this against a live server. Also some code polishing and documentation for fellow contributors.