### PR TITLE
Referrer improvements

### DIFF
--- a/exampleapp/build.gradle
+++ b/exampleapp/build.gradle
@@ -21,4 +21,5 @@ dependencies {
     compile project(":piwik-sdk")
     compile 'com.android.support:appcompat-v7:23.1.1'
     compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.jakewharton:butterknife:7.0.1'
 }

--- a/exampleapp/src/main/java/com/piwik/demo/DemoActivity.java
+++ b/exampleapp/src/main/java/com/piwik/demo/DemoActivity.java
@@ -13,7 +13,6 @@ import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Button;
 import android.widget.EditText;
 
 import org.piwik.sdk.PiwikApplication;
@@ -24,6 +23,9 @@ import org.piwik.sdk.ecommerce.EcommerceItems;
 import java.util.Arrays;
 import java.util.List;
 
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+
 
 public class DemoActivity extends ActionBarActivity {
     int cartItems = 0;
@@ -33,8 +35,8 @@ public class DemoActivity extends ActionBarActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_demo);
+        ButterKnife.bind(this);
         items = new EcommerceItems();
-        initTrackViewListeners();
     }
 
 
@@ -60,92 +62,64 @@ public class DemoActivity extends ActionBarActivity {
         return super.onOptionsItemSelected(item);
     }
 
-    protected void initTrackViewListeners() {
-        // simple track view
-        Button button = (Button) findViewById(R.id.trackMainScreenViewButton);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                ((PiwikApplication) getApplication()).getTracker().trackScreenView("/", "Main screen");
-            }
-        });
-
-        // custom vars track view
-        button = (Button) findViewById(R.id.trackCustomVarsButton);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                ((PiwikApplication) getApplication()).getTracker()
-                        .trackScreenView(
-                                new TrackMe()
-                                        .setScreenCustomVariable(1, "first", "var")
-                                        .setScreenCustomVariable(2, "second", "long value"),
-                                "/custom_vars", "Custom Vars");
-            }
-        });
-
-        // exception tracking
-        button = (Button) findViewById(R.id.raiseExceptionButton);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                ((PiwikApplication) getApplication()).getTracker().trackException(new Exception("OnPurposeException"), "Crash button", false);
-            }
-        });
-
-        // goal tracking
-        button = (Button) findViewById(R.id.trackGoalButton);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                int revenue;
-                try {
-                    revenue = Integer.valueOf(
-                            ((EditText) findViewById(R.id.goalTextEditView)).getText().toString()
-                    );
-                } catch (Exception e) {
-                    ((PiwikApplication) getApplication()).getTracker().trackException(e, "wrong revenue", false);
-                    revenue = 0;
-                }
-                ((PiwikApplication) getApplication()).getTracker().trackGoal(1, revenue);
-            }
-        });
-
-        //ecommerce tracking
-        button = (Button) findViewById(R.id.addEcommerceItemButton);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                List<String> skus = Arrays.asList("00001", "00002", "00003", "00004");
-                List<String> names = Arrays.asList("Silly Putty", "Fishing Rod", "Rubber Boots", "Cool Ranch Doritos");
-                List<String> categories = Arrays.asList("Toys & Games", "Hunting & Fishing", "Footwear", "Grocery");
-                List<Integer> prices = Arrays.asList(449, 3495, 2450, 250);
-
-                int index = cartItems % 4;
-                int quantity = (cartItems / 4) + 1;
-
-                items.addItem(skus.get(index), names.get(index), categories.get(index), prices.get(index), quantity);
-                cartItems++;
-            }
-        });
-
-        button = (Button) findViewById(R.id.trackEcommerceCartUpdateButton);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Tracker tracker = ((PiwikApplication) getApplication()).getTracker();
-                tracker.trackEcommerceCartUpdate(8600, items);
-            }
-        });
-
-        button = (Button) findViewById(R.id.completeEcommerceOrderButton);
-        button.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Tracker tracker = ((PiwikApplication) getApplication()).getTracker();
-                tracker.trackEcommerceOrder(String.valueOf(10000 * Math.random()), 10000, 1000, 2000, 3000, 500, items);
-            }
-        });
-
+    @OnClick(R.id.trackMainScreenViewButton)
+    void onTrackMainScreenClicked(View view) {
+        ((PiwikApplication) getApplication()).getTracker().trackScreenView("/", "Main screen");
     }
+
+    @OnClick(R.id.trackCustomVarsButton)
+    void onTrackCustomVarsClicked(View view) {
+        ((PiwikApplication) getApplication()).getTracker()
+                .trackScreenView(
+                        new TrackMe()
+                                .setScreenCustomVariable(1, "first", "var")
+                                .setScreenCustomVariable(2, "second", "long value"),
+                        "/custom_vars", "Custom Vars");
+    }
+
+    @OnClick(R.id.raiseExceptionButton)
+    void onRaiseExceptionClicked(View view) {
+        ((PiwikApplication) getApplication()).getTracker().trackException(new Exception("OnPurposeException"), "Crash button", false);
+    }
+
+    @OnClick(R.id.trackGoalButton)
+    void onTrackGoalClicked(View view) {
+        int revenue;
+        try {
+            revenue = Integer.valueOf(
+                    ((EditText) findViewById(R.id.goalTextEditView)).getText().toString()
+            );
+        } catch (Exception e) {
+            ((PiwikApplication) getApplication()).getTracker().trackException(e, "wrong revenue", false);
+            revenue = 0;
+        }
+        ((PiwikApplication) getApplication()).getTracker().trackGoal(1, revenue);
+    }
+
+    @OnClick(R.id.addEcommerceItemButton)
+    void onAddEcommerceItemClicked(View view) {
+        List<String> skus = Arrays.asList("00001", "00002", "00003", "00004");
+        List<String> names = Arrays.asList("Silly Putty", "Fishing Rod", "Rubber Boots", "Cool Ranch Doritos");
+        List<String> categories = Arrays.asList("Toys & Games", "Hunting & Fishing", "Footwear", "Grocery");
+        List<Integer> prices = Arrays.asList(449, 3495, 2450, 250);
+
+        int index = cartItems % 4;
+        int quantity = (cartItems / 4) + 1;
+
+        items.addItem(skus.get(index), names.get(index), categories.get(index), prices.get(index), quantity);
+        cartItems++;
+    }
+
+    @OnClick(R.id.trackEcommerceCartUpdateButton)
+    void onTrackEcommerceCartUpdateClicked(View view) {
+        Tracker tracker = ((PiwikApplication) getApplication()).getTracker();
+        tracker.trackEcommerceCartUpdate(8600, items);
+    }
+
+    @OnClick(R.id.completeEcommerceOrderButton)
+    void onCompleteEcommerceOrderClicked(View view) {
+        Tracker tracker = ((PiwikApplication) getApplication()).getTracker();
+        tracker.trackEcommerceOrder(String.valueOf(10000 * Math.random()), 10000, 1000, 2000, 3000, 500, items);
+    }
+
 }

--- a/exampleapp/src/main/java/com/piwik/demo/DemoApp.java
+++ b/exampleapp/src/main/java/com/piwik/demo/DemoApp.java
@@ -43,7 +43,7 @@ public class DemoApp extends PiwikApplication {
 
         // Track this app install, this will only trigger once per app version.
         // i.e. "http://com.piwik.demo:1/185DECB5CFE28FDB2F45887022D668B4"
-        getTracker().trackAppDownload(this, Tracker.ExtraIdentifier.APK_CHECKSUM);
+        getTracker().trackAppDownload(Tracker.ExtraIdentifier.APK_CHECKSUM);
         // Alternative:
         // i.e. "http://com.piwik.demo:1/com.android.vending"
         // getTracker().trackAppDownload();

--- a/piwik-sdk/src/main/AndroidManifest.xml
+++ b/piwik-sdk/src/main/AndroidManifest.xml
@@ -4,4 +4,14 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
+    <application>
+        <receiver
+            android:name=".InstallReferrerReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.android.vending.INSTALL_REFERRER"/>
+            </intent-filter>
+        </receiver>
+    </application>
 </manifest>

--- a/piwik-sdk/src/main/java/org/piwik/sdk/DownloadTrackingHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/DownloadTrackingHelper.java
@@ -1,0 +1,123 @@
+package org.piwik.sdk;
+
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+
+import org.piwik.sdk.Tracker.ExtraIdentifier;
+import org.piwik.sdk.tools.Checksum;
+import org.piwik.sdk.tools.Logy;
+
+import java.io.File;
+
+class DownloadTrackingHelper {
+    protected static final String LOGGER_TAG = Piwik.LOGGER_PREFIX + "DownloadTrackingHelper";
+    private static final String INSTALL_SOURCE_GOOGLE_PLAY = "com.android.vending";
+    private final Tracker mTracker;
+    private final Object TRACK_ONCE_LOCK = new Object();
+    private final PackageManager mPackMan;
+    private final String mPackageName;
+    private final SharedPreferences mPreferences;
+    private final Piwik mPiwik;
+    private final Context mContext;
+
+    DownloadTrackingHelper(Tracker tracker) {
+        mTracker = tracker;
+        mPiwik = tracker.getPiwik();
+        mContext = mPiwik.getContext();
+        mPreferences = mPiwik.getSharedPreferences();
+        mPackageName = mContext.getPackageName();
+        mPackMan = mContext.getPackageManager();
+    }
+
+    void trackOnce(@NonNull ExtraIdentifier extra) {
+        try {
+            PackageInfo pkgInfo = mContext.getPackageManager().getPackageInfo(mContext.getPackageName(), 0);
+            String firedKey = "downloaded:" + pkgInfo.packageName + ":" + pkgInfo.versionCode;
+            synchronized (TRACK_ONCE_LOCK) {
+                if (!mPreferences.getBoolean(firedKey, false)) {
+                    mPreferences.edit().putBoolean(firedKey, true).apply();
+                    trackNewAppDownload(extra);
+                }
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void trackNewAppDownload(@NonNull final ExtraIdentifier extra) {
+        String referringApp = mPackMan.getInstallerPackageName(mPackageName);
+        if (INSTALL_SOURCE_GOOGLE_PLAY.equals(referringApp)) {
+            Logy.d(LOGGER_TAG, "Google Play is install source, deferring tracking.");
+            // Installed by Google Play
+            // If we are called from from within Application.onCreate wait for the install REFERRER
+            new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    trackNewAppDownloadInternal(extra);
+                }
+            }, 3000);
+        } else {
+            trackNewAppDownloadInternal(extra);
+        }
+    }
+
+    void trackNewAppDownloadInternal(@NonNull ExtraIdentifier extra) {
+        Logy.d(LOGGER_TAG, "Tracking app download...");
+        StringBuilder installationIdentifier = new StringBuilder();
+        try {
+            installationIdentifier.append("http://").append(mPackageName); // Identifies the app
+
+            PackageInfo pkgInfo = mPackMan.getPackageInfo(mPackageName, 0);
+            installationIdentifier.append(":").append(pkgInfo.versionCode);
+
+            if (extra == ExtraIdentifier.APK_CHECKSUM) {
+                ApplicationInfo appInfo = mPackMan.getApplicationInfo(mPackageName, 0);
+                if (appInfo.sourceDir != null) {
+                    String md5Identifier = null;
+                    try {
+                        md5Identifier = Checksum.getMD5Checksum(new File(appInfo.sourceDir));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    if (md5Identifier != null)
+                        installationIdentifier.append("/").append(md5Identifier);
+                }
+            }
+
+            // Usual USEFUL values of this field will be: "com.android.vending" or "com.android.browser", i.e. app packagenames.
+            // This is not guaranteed, values can also look like: app_process /system/bin com.android.commands.pm.Pm install -r /storage/sdcard0/...
+            String referringApp = mPackMan.getInstallerPackageName(mPackageName);
+            if (referringApp != null && referringApp.length() > 200)
+                referringApp = referringApp.substring(0, 200);
+
+            if (referringApp != null && referringApp.equals("com.android.vending")) {
+                // For this type of install source we could have extra referral information
+                String referrerExtras = mPreferences.getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
+                if (referrerExtras != null) {
+                    referringApp = referringApp + "/?" + referrerExtras;
+                }
+            }
+
+            if (referringApp != null)
+                referringApp = "http://" + referringApp;
+
+            mTracker.track(new TrackMe()
+                    .set(QueryParams.EVENT_CATEGORY, "Application")
+                    .set(QueryParams.EVENT_ACTION, "downloaded")
+                    .set(QueryParams.ACTION_NAME, "application/downloaded")
+                    .set(QueryParams.URL_PATH, "/application/downloaded")
+                    .set(QueryParams.DOWNLOAD, installationIdentifier.toString())
+                    .set(QueryParams.REFERRER, referringApp)); // Can be null in which case the TrackMe removes the REFERRER parameter.
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        Logy.d(LOGGER_TAG, "... app download tracked.");
+    }
+}

--- a/piwik-sdk/src/main/java/org/piwik/sdk/DownloadTrackingHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/DownloadTrackingHelper.java
@@ -97,7 +97,7 @@ class DownloadTrackingHelper {
             if (referringApp != null && referringApp.length() > 200)
                 referringApp = referringApp.substring(0, 200);
 
-            if (referringApp != null && referringApp.equals("com.android.vending")) {
+            if (referringApp != null && referringApp.equals(INSTALL_SOURCE_GOOGLE_PLAY)) {
                 // For this type of install source we could have extra referral information
                 String referrerExtras = mPreferences.getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
                 if (referrerExtras != null) {

--- a/piwik-sdk/src/main/java/org/piwik/sdk/DownloadTrackingHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/DownloadTrackingHelper.java
@@ -3,7 +3,6 @@ package org.piwik.sdk;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Handler;
@@ -70,54 +69,54 @@ class DownloadTrackingHelper {
 
     void trackNewAppDownloadInternal(@NonNull ExtraIdentifier extra) {
         Logy.d(LOGGER_TAG, "Tracking app download...");
-        StringBuilder installationIdentifier = new StringBuilder();
+        PackageInfo pkgInfo = null;
         try {
-            installationIdentifier.append("http://").append(mPackageName); // Identifies the app
-
-            PackageInfo pkgInfo = mPackMan.getPackageInfo(mPackageName, 0);
-            installationIdentifier.append(":").append(pkgInfo.versionCode);
-
-            if (extra == ExtraIdentifier.APK_CHECKSUM) {
-                ApplicationInfo appInfo = mPackMan.getApplicationInfo(mPackageName, 0);
-                if (appInfo.sourceDir != null) {
-                    String md5Identifier = null;
-                    try {
-                        md5Identifier = Checksum.getMD5Checksum(new File(appInfo.sourceDir));
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                    if (md5Identifier != null)
-                        installationIdentifier.append("/").append(md5Identifier);
-                }
-            }
-
-            // Usual USEFUL values of this field will be: "com.android.vending" or "com.android.browser", i.e. app packagenames.
-            // This is not guaranteed, values can also look like: app_process /system/bin com.android.commands.pm.Pm install -r /storage/sdcard0/...
-            String referringApp = mPackMan.getInstallerPackageName(mPackageName);
-            if (referringApp != null && referringApp.length() > 200)
-                referringApp = referringApp.substring(0, 200);
-
-            if (referringApp != null && referringApp.equals(INSTALL_SOURCE_GOOGLE_PLAY)) {
-                // For this type of install source we could have extra referral information
-                String referrerExtras = mPreferences.getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
-                if (referrerExtras != null) {
-                    referringApp = referringApp + "/?" + referrerExtras;
-                }
-            }
-
-            if (referringApp != null)
-                referringApp = "http://" + referringApp;
-
-            mTracker.track(new TrackMe()
-                    .set(QueryParams.EVENT_CATEGORY, "Application")
-                    .set(QueryParams.EVENT_ACTION, "downloaded")
-                    .set(QueryParams.ACTION_NAME, "application/downloaded")
-                    .set(QueryParams.URL_PATH, "/application/downloaded")
-                    .set(QueryParams.DOWNLOAD, installationIdentifier.toString())
-                    .set(QueryParams.REFERRER, referringApp)); // Can be null in which case the TrackMe removes the REFERRER parameter.
+            pkgInfo = mPackMan.getPackageInfo(mPackageName, 0);
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();
         }
+        if (pkgInfo == null)
+            return;
+
+        StringBuilder installIdentifier = new StringBuilder();
+        installIdentifier.append("http://").append(mPackageName).append(":").append(pkgInfo.versionCode);
+
+        if (extra == ExtraIdentifier.APK_CHECKSUM) {
+            if (pkgInfo.applicationInfo != null && pkgInfo.applicationInfo.sourceDir != null) {
+                try {
+                    String md5Identifier = Checksum.getMD5Checksum(new File(pkgInfo.applicationInfo.sourceDir));
+                    if (md5Identifier != null)
+                        installIdentifier.append("/").append(md5Identifier);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        // Usual USEFUL values of this field will be: "com.android.vending" or "com.android.browser", i.e. app packagenames.
+        // This is not guaranteed, values can also look like: app_process /system/bin com.android.commands.pm.Pm install -r /storage/sdcard0/...
+        String referringApp = mPackMan.getInstallerPackageName(mPackageName);
+        if (referringApp != null && referringApp.length() > 200)
+            referringApp = referringApp.substring(0, 200);
+
+        if (referringApp != null && referringApp.equals(INSTALL_SOURCE_GOOGLE_PLAY)) {
+            // For this type of install source we could have extra referral information
+            String referrerExtras = mPreferences.getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
+            if (referrerExtras != null)
+                referringApp = referringApp + "/?" + referrerExtras;
+        }
+
+        if (referringApp != null)
+            referringApp = "http://" + referringApp;
+
+        mTracker.track(new TrackMe()
+                .set(QueryParams.EVENT_CATEGORY, "Application")
+                .set(QueryParams.EVENT_ACTION, "downloaded")
+                .set(QueryParams.ACTION_NAME, "application/downloaded")
+                .set(QueryParams.URL_PATH, "/application/downloaded")
+                .set(QueryParams.DOWNLOAD, installIdentifier.toString())
+                .set(QueryParams.REFERRER, referringApp)); // Can be null in which case the TrackMe removes the REFERRER parameter.
+
         Logy.d(LOGGER_TAG, "... app download tracked.");
     }
 }

--- a/piwik-sdk/src/main/java/org/piwik/sdk/InstallReferrerReceiver.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/InstallReferrerReceiver.java
@@ -1,0 +1,41 @@
+package org.piwik.sdk;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+
+import org.piwik.sdk.tools.Logy;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+public class InstallReferrerReceiver extends BroadcastReceiver {
+    private static final String LOGGER_TAG = Piwik.LOGGER_PREFIX + "InstallReferrerReceiver";
+
+    // Google Play
+    private static final String REFERRER_SOURCE_GPLAY = "com.android.vending.INSTALL_REFERRER";
+    static final String ARG_KEY_GPLAY_REFERRER = "referrer";
+
+    static final String PREF_KEY_INSTALL_REFERRER_EXTRAS = "referrer.extras";
+    public static final List<String> RESPONSIBILITIES = Arrays.asList(REFERRER_SOURCE_GPLAY);
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Logy.d("LOGGER_TAG", intent.toString());
+        if (intent.getAction() == null || !RESPONSIBILITIES.contains(intent.getAction())) {
+            Logy.w(LOGGER_TAG, "Got called outside our responsibilities: " + intent.getAction());
+            return;
+        }
+        SharedPreferences piwikPreferences = Piwik.getInstance(context.getApplicationContext()).getSharedPreferences();
+        if (intent.getAction().equals(REFERRER_SOURCE_GPLAY)) {
+            String referrer = intent.getStringExtra(ARG_KEY_GPLAY_REFERRER);
+            if (referrer != null) {
+                piwikPreferences.edit().putString(PREF_KEY_INSTALL_REFERRER_EXTRAS, referrer).apply();
+                Logy.d("LOGGER_TAG", "Stored Google Play referrer extras: " + referrer);
+            }
+        }
+    }
+}
+

--- a/piwik-sdk/src/main/java/org/piwik/sdk/InstallReferrerReceiver.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/InstallReferrerReceiver.java
@@ -15,11 +15,11 @@ public class InstallReferrerReceiver extends BroadcastReceiver {
     private static final String LOGGER_TAG = Piwik.LOGGER_PREFIX + "InstallReferrerReceiver";
 
     // Google Play
-    private static final String REFERRER_SOURCE_GPLAY = "com.android.vending.INSTALL_REFERRER";
+    static final String REFERRER_SOURCE_GPLAY = "com.android.vending.INSTALL_REFERRER";
     static final String ARG_KEY_GPLAY_REFERRER = "referrer";
 
     static final String PREF_KEY_INSTALL_REFERRER_EXTRAS = "referrer.extras";
-    public static final List<String> RESPONSIBILITIES = Arrays.asList(REFERRER_SOURCE_GPLAY);
+    static final List<String> RESPONSIBILITIES = Arrays.asList(REFERRER_SOURCE_GPLAY);
 
     @Override
     public void onReceive(Context context, Intent intent) {

--- a/piwik-sdk/src/main/java/org/piwik/sdk/InstallReferrerReceiver.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/InstallReferrerReceiver.java
@@ -23,9 +23,13 @@ public class InstallReferrerReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        Logy.d("LOGGER_TAG", intent.toString());
+        Logy.d(LOGGER_TAG, intent.toString());
         if (intent.getAction() == null || !RESPONSIBILITIES.contains(intent.getAction())) {
             Logy.w(LOGGER_TAG, "Got called outside our responsibilities: " + intent.getAction());
+            return;
+        }
+        if (intent.getBooleanExtra("forwarded", false)) {
+            Logy.d(LOGGER_TAG, "Dropping forwarded intent");
             return;
         }
         SharedPreferences piwikPreferences = Piwik.getInstance(context.getApplicationContext()).getSharedPreferences();
@@ -33,9 +37,14 @@ public class InstallReferrerReceiver extends BroadcastReceiver {
             String referrer = intent.getStringExtra(ARG_KEY_GPLAY_REFERRER);
             if (referrer != null) {
                 piwikPreferences.edit().putString(PREF_KEY_INSTALL_REFERRER_EXTRAS, referrer).apply();
-                Logy.d("LOGGER_TAG", "Stored Google Play referrer extras: " + referrer);
+                Logy.d(LOGGER_TAG, "Stored Google Play referrer extras: " + referrer);
             }
         }
+        // Forward to other possible recipients
+        intent.setComponent(null);
+        intent.setPackage(context.getPackageName());
+        intent.putExtra("forwarded", true);
+        context.sendBroadcast(intent);
     }
 }
 

--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -430,7 +430,15 @@ public class Tracker {
     }
 
     public enum ExtraIdentifier {
+        /**
+         * The MD5 checksum of the apk file.
+         * com.example.pkg:1/ABCDEF01234567
+         */
         APK_CHECKSUM,
+        /**
+         * No extra identifier.
+         * com.example.pkg:1
+         */
         NONE
     }
 

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
@@ -187,8 +187,8 @@ public class Dispatcher {
             return false;
 
         if (mPiwik.isDryRun()) {
-            Logy.d(LOGGER_TAG, "DryRun, stored HttpRequest, now " + mDryRunOutput.size());
             mDryRunOutput.add(packet);
+            Logy.d(LOGGER_TAG, "DryRun, stored HttpRequest, now " + mDryRunOutput.size());
             return true;
         }
 

--- a/piwik-sdk/src/test/java/org/piwik/sdk/DispatcherTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/DispatcherTest.java
@@ -15,6 +15,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.piwik.sdk.dispatcher.Dispatcher;
 import org.piwik.sdk.dispatcher.Packet;
+import org.piwik.sdk.testhelper.FullEnvTestRunner;
+import org.piwik.sdk.testhelper.PiwikTestApplication;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
@@ -35,10 +37,10 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("deprecation")
 @Config(emulateSdk = 18, manifest = Config.NONE)
 @RunWith(FullEnvTestRunner.class)
-public class TestDispatcher {
+public class DispatcherTest {
 
     public Tracker createTracker() throws MalformedURLException {
-        TestPiwikApplication app = (TestPiwikApplication) Robolectric.application;
+        PiwikTestApplication app = (PiwikTestApplication) Robolectric.application;
         return Piwik.getInstance(Robolectric.application).newTracker(app.getTrackerUrl(), app.getSiteId());
     }
 

--- a/piwik-sdk/src/test/java/org/piwik/sdk/FullEnvPackageManager.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/FullEnvPackageManager.java
@@ -11,7 +11,6 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInstaller;
-import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
@@ -36,6 +35,11 @@ public class FullEnvPackageManager extends RobolectricPackageManager {
     @Override
     public Intent getLeanbackLaunchIntentForPackage(String packageName) {
         return null;
+    }
+
+    @Override
+    public boolean isPermissionRevokedByPolicy(String permName, String pkgName) {
+        return false;
     }
 
     @Override

--- a/piwik-sdk/src/test/java/org/piwik/sdk/InstallReferrerReceiverTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/InstallReferrerReceiverTest.java
@@ -1,0 +1,37 @@
+package org.piwik.sdk;
+
+import android.content.Intent;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertEquals;
+
+
+@Config(emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class InstallReferrerReceiverTest extends PiwikDefaultTest {
+
+    @Test
+    public void testReceiveGooglePlay() throws Exception {
+        InstallReferrerReceiver receiver = new InstallReferrerReceiver();
+        Intent testIntent = new Intent("com.android.vending.INSTALL_REFERRER");
+        testIntent.setPackage(Robolectric.application.getPackageName());
+
+        String testReferrerData1 = "utm_source=test_source&utm_medium=test_medium&utm_term=test_term&utm_content=test_content&utm_campaign=test_name";
+        testIntent.putExtra(InstallReferrerReceiver.ARG_KEY_GPLAY_REFERRER, testReferrerData1);
+        receiver.onReceive(Robolectric.application.getApplicationContext(), testIntent);
+        String referrerDataFromPreferences = getPiwik().getSharedPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
+        assertEquals(testReferrerData1, referrerDataFromPreferences);
+
+        String testReferrerData2 = "pk_campaign=Email-Nov2011&pk_kwd=OrderNow";
+        testIntent.putExtra(InstallReferrerReceiver.ARG_KEY_GPLAY_REFERRER, testReferrerData2);
+        receiver.onReceive(Robolectric.application.getApplicationContext(), testIntent);
+        referrerDataFromPreferences = getPiwik().getSharedPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
+        assertEquals(testReferrerData2, referrerDataFromPreferences);
+    }
+
+}

--- a/piwik-sdk/src/test/java/org/piwik/sdk/InstallReferrerReceiverTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/InstallReferrerReceiverTest.java
@@ -15,7 +15,8 @@ import static junit.framework.Assert.assertTrue;
 @Config(emulateSdk = 18, manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public class InstallReferrerReceiverTest extends PiwikDefaultTest {
-
+    // How to test on a live device:
+    // adb shell am broadcast -a com.android.vending.INSTALL_REFERRER -n com.piwik.demo/org.piwik.sdk.InstallReferrerReceiver --es "referrer" "utm_medium%3Dpartner%26utm_campaign%3Dpart
     @Test
     public void testReceiveGooglePlay() throws Exception {
         InstallReferrerReceiver receiver = new InstallReferrerReceiver();

--- a/piwik-sdk/src/test/java/org/piwik/sdk/InstallReferrerReceiverTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/InstallReferrerReceiverTest.java
@@ -9,6 +9,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 
 
 @Config(emulateSdk = 18, manifest = Config.NONE)
@@ -26,9 +27,18 @@ public class InstallReferrerReceiverTest extends PiwikDefaultTest {
         receiver.onReceive(Robolectric.application.getApplicationContext(), testIntent);
         String referrerDataFromPreferences = getPiwik().getSharedPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
         assertEquals(testReferrerData1, referrerDataFromPreferences);
+        assertTrue(testIntent.getBooleanExtra("forwarded", false));
+
 
         String testReferrerData2 = "pk_campaign=Email-Nov2011&pk_kwd=OrderNow";
         testIntent.putExtra(InstallReferrerReceiver.ARG_KEY_GPLAY_REFERRER, testReferrerData2);
+
+        receiver.onReceive(Robolectric.application.getApplicationContext(), testIntent);
+        referrerDataFromPreferences = getPiwik().getSharedPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
+        assertEquals(testReferrerData1, referrerDataFromPreferences);
+
+
+        testIntent.putExtra("forwarded", false);
         receiver.onReceive(Robolectric.application.getApplicationContext(), testIntent);
         referrerDataFromPreferences = getPiwik().getSharedPreferences().getString(InstallReferrerReceiver.PREF_KEY_INSTALL_REFERRER_EXTRAS, null);
         assertEquals(testReferrerData2, referrerDataFromPreferences);

--- a/piwik-sdk/src/test/java/org/piwik/sdk/InstallReferrerReceiverTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/InstallReferrerReceiverTest.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.piwik.sdk.testhelper.DefaultTestCase;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -14,7 +15,7 @@ import static junit.framework.Assert.assertTrue;
 
 @Config(emulateSdk = 18, manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
-public class InstallReferrerReceiverTest extends PiwikDefaultTest {
+public class InstallReferrerReceiverTest extends DefaultTestCase {
     // How to test on a live device:
     // adb shell am broadcast -a com.android.vending.INSTALL_REFERRER -n com.piwik.demo/org.piwik.sdk.InstallReferrerReceiver --es "referrer" "utm_medium%3Dpartner%26utm_campaign%3Dpart
     @Test

--- a/piwik-sdk/src/test/java/org/piwik/sdk/PiwikApplicationTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/PiwikApplicationTest.java
@@ -1,0 +1,75 @@
+/*
+ * Android SDK for Piwik
+ *
+ * @link https://github.com/piwik/piwik-android-sdk
+ * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
+ */
+
+package org.piwik.sdk;
+
+import android.app.Application;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.piwik.sdk.testhelper.FullEnvTestRunner;
+import org.piwik.sdk.testhelper.PiwikTestApplication;
+import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+@Config(emulateSdk = 18, manifest = Config.NONE)
+@RunWith(FullEnvTestRunner.class)
+public class PiwikApplicationTest {
+
+    @Test
+    public void testNewTracker() throws Exception {
+        PiwikTestApplication app = (PiwikTestApplication) Robolectric.application;
+        Tracker tracker = Piwik.getInstance(Robolectric.application).newTracker(app.getTrackerUrl(), app.getSiteId());
+        assertNotNull(tracker);
+        assertEquals(new URL(app.getTrackerUrl() + "/piwik.php"), tracker.getAPIUrl());
+        assertEquals(app.getSiteId(), Integer.valueOf(tracker.getSiteId()));
+    }
+
+    @Test
+    public void testOptions() throws Exception {
+        Piwik piwik = Piwik.getInstance(Robolectric.application);
+
+        piwik.setDryRun(true);
+        piwik.setOptOut(true);
+        piwik.setDebug(true);
+
+        assertTrue(piwik.isDryRun());
+        assertTrue(piwik.isOptOut());
+        assertTrue(piwik.isDebug());
+
+        piwik.setDryRun(false);
+        piwik.setOptOut(false);
+        piwik.setDebug(false);
+
+        assertFalse(piwik.isDryRun());
+        assertFalse(piwik.isOptOut());
+        assertFalse(piwik.isDebug());
+    }
+
+    @Test
+    public void testLowMemoryDispatch() throws Exception {
+        PiwikTestApplication app = (PiwikTestApplication) Robolectric.application;
+        app.getPiwik().setDryRun(true);
+        Tracker tracker = app.getTracker();
+        assertNotNull(tracker);
+        tracker.setDispatchInterval(-1);
+        tracker.trackScreenView("test");
+        Thread.sleep(50);
+        assertTrue(tracker.getDispatcher().getDryRunOutput().isEmpty());
+        app.onTrimMemory(Application.TRIM_MEMORY_UI_HIDDEN);
+        Thread.sleep(50);
+        assertFalse(tracker.getDispatcher().getDryRunOutput().isEmpty());
+    }
+}

--- a/piwik-sdk/src/test/java/org/piwik/sdk/PiwikDefaultTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/PiwikDefaultTest.java
@@ -1,0 +1,28 @@
+package org.piwik.sdk;
+
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
+
+import java.net.MalformedURLException;
+
+@Config(emulateSdk = 18, manifest = Config.NONE)
+@RunWith(FullEnvTestRunner.class)
+public abstract class PiwikDefaultTest {
+    public Tracker createTracker() throws MalformedURLException {
+        TestPiwikApplication app = (TestPiwikApplication) Robolectric.application;
+        return Piwik.getInstance(Robolectric.application).newTracker(app.getTrackerUrl(), app.getSiteId());
+    }
+
+    public Piwik getPiwik() {
+        return Piwik.getInstance(Robolectric.application);
+    }
+
+    @Before
+    public void setup() {
+        Piwik.getInstance(Robolectric.application).setDryRun(true);
+        Piwik.getInstance(Robolectric.application).setOptOut(true);
+        Piwik.getInstance(Robolectric.application).getSharedPreferences().edit().clear().apply();
+    }
+}

--- a/piwik-sdk/src/test/java/org/piwik/sdk/QuickTrackTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/QuickTrackTest.java
@@ -12,6 +12,7 @@ import android.util.Pair;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.piwik.sdk.testhelper.FullEnvTestRunner;
 import org.piwik.sdk.tools.UrlHelper;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -5,10 +5,12 @@ import android.util.Pair;
 
 import org.json.JSONArray;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.piwik.sdk.ecommerce.EcommerceItems;
 import org.piwik.sdk.plugins.CustomDimensions;
 import org.piwik.sdk.tools.UrlHelper;
 import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -33,6 +35,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
+@Config(emulateSdk = 18, manifest = Config.NONE)
+@RunWith(FullEnvTestRunner.class)
 public class TrackerTest extends PiwikDefaultTest {
 
     @Test

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -8,6 +8,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.piwik.sdk.ecommerce.EcommerceItems;
 import org.piwik.sdk.plugins.CustomDimensions;
+import org.piwik.sdk.testhelper.DefaultTestCase;
+import org.piwik.sdk.testhelper.FullEnvPackageManager;
+import org.piwik.sdk.testhelper.FullEnvTestRunner;
+import org.piwik.sdk.testhelper.PiwikTestApplication;
+import org.piwik.sdk.testhelper.TestActivity;
 import org.piwik.sdk.tools.UrlHelper;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
@@ -37,7 +42,7 @@ import static org.junit.Assert.assertTrue;
 
 @Config(emulateSdk = 18, manifest = Config.NONE)
 @RunWith(FullEnvTestRunner.class)
-public class TrackerTest extends PiwikDefaultTest {
+public class TrackerTest extends DefaultTestCase {
 
     @Test
     public void testPiwikAutoBindActivities() throws Exception {
@@ -311,7 +316,7 @@ public class TrackerTest extends PiwikDefaultTest {
                 }).start();
             }
             Thread.sleep(500);
-            List<String> flattenedQueries = TestDispatcher.getFlattenedQueries(tracker.getDispatcher().getDryRunOutput());
+            List<String> flattenedQueries = DispatcherTest.getFlattenedQueries(tracker.getDispatcher().getDryRunOutput());
             assertEquals(count, flattenedQueries.size());
             int found = 0;
             for (String query : flattenedQueries) {
@@ -485,10 +490,10 @@ public class TrackerTest extends PiwikDefaultTest {
         checkNewAppDownload(queryParams);
         Matcher m = REGEX_DOWNLOADTRACK.matcher(queryParams.get(QueryParams.DOWNLOAD));
         assertTrue(m.matches());
-        assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
-        assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
-        assertEquals(TestPiwikApplication.FAKE_APK_DATA_MD5, m.group(3));
-        assertEquals("http://" + TestPiwikApplication.INSTALLER_PACKAGENAME, queryParams.get(QueryParams.REFERRER));
+        assertEquals(PiwikTestApplication.PACKAGENAME, m.group(1));
+        assertEquals(PiwikTestApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
+        assertEquals(PiwikTestApplication.FAKE_APK_DATA_MD5, m.group(3));
+        assertEquals("http://" + PiwikTestApplication.INSTALLER_PACKAGENAME, queryParams.get(QueryParams.REFERRER));
 
         tracker.clearLastEvent();
 
@@ -499,10 +504,10 @@ public class TrackerTest extends PiwikDefaultTest {
         m = REGEX_DOWNLOADTRACK.matcher(downloadParams);
         assertTrue(downloadParams, m.matches());
         assertEquals(3, m.groupCount());
-        assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
-        assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
+        assertEquals(PiwikTestApplication.PACKAGENAME, m.group(1));
+        assertEquals(PiwikTestApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
         assertEquals(null, m.group(3));
-        assertEquals("http://" + TestPiwikApplication.INSTALLER_PACKAGENAME, queryParams.get(QueryParams.REFERRER));
+        assertEquals("http://" + PiwikTestApplication.INSTALLER_PACKAGENAME, queryParams.get(QueryParams.REFERRER));
 
         tracker.clearLastEvent();
 
@@ -514,8 +519,8 @@ public class TrackerTest extends PiwikDefaultTest {
         m = REGEX_DOWNLOADTRACK.matcher(queryParams.get(QueryParams.DOWNLOAD));
         assertTrue(m.matches());
         assertEquals(3, m.groupCount());
-        assertEquals(TestPiwikApplication.PACKAGENAME, m.group(1));
-        assertEquals(TestPiwikApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
+        assertEquals(PiwikTestApplication.PACKAGENAME, m.group(1));
+        assertEquals(PiwikTestApplication.VERSION_CODE, Integer.parseInt(m.group(2)));
         assertEquals(null, m.group(3));
         assertEquals(null, queryParams.get(QueryParams.REFERRER));
     }

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -480,6 +480,7 @@ public class TrackerTest extends PiwikDefaultTest {
     public void testTrackNewAppDownload() throws Exception {
         Tracker tracker = createTracker();
         tracker.trackNewAppDownload(Tracker.ExtraIdentifier.APK_CHECKSUM);
+        Thread.sleep(100); // APK checksum happens off thread
         QueryHashMap<String, String> queryParams = parseEventUrl(tracker.getLastEvent());
         checkNewAppDownload(queryParams);
         Matcher m = REGEX_DOWNLOADTRACK.matcher(queryParams.get(QueryParams.DOWNLOAD));

--- a/piwik-sdk/src/test/java/org/piwik/sdk/ecommerce/EcommerceItemsTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/ecommerce/EcommerceItemsTest.java
@@ -2,7 +2,7 @@ package org.piwik.sdk.ecommerce;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.piwik.sdk.FullEnvTestRunner;
+import org.piwik.sdk.testhelper.FullEnvTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.Locale;

--- a/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/DefaultTestCase.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/DefaultTestCase.java
@@ -1,7 +1,9 @@
-package org.piwik.sdk;
+package org.piwik.sdk.testhelper;
 
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.piwik.sdk.Piwik;
+import org.piwik.sdk.Tracker;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
@@ -9,9 +11,9 @@ import java.net.MalformedURLException;
 
 @Config(emulateSdk = 18, manifest = Config.NONE)
 @RunWith(FullEnvTestRunner.class)
-public abstract class PiwikDefaultTest {
+public abstract class DefaultTestCase {
     public Tracker createTracker() throws MalformedURLException {
-        TestPiwikApplication app = (TestPiwikApplication) Robolectric.application;
+        PiwikTestApplication app = (PiwikTestApplication) Robolectric.application;
         return Piwik.getInstance(Robolectric.application).newTracker(app.getTrackerUrl(), app.getSiteId());
     }
 

--- a/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/FullEnvPackageManager.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/FullEnvPackageManager.java
@@ -5,7 +5,7 @@
  * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
  */
 
-package org.piwik.sdk;
+package org.piwik.sdk.testhelper;
 
 import android.content.ComponentName;
 import android.content.Intent;

--- a/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/FullEnvTestLifeCycle.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/FullEnvTestLifeCycle.java
@@ -5,7 +5,7 @@
  * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
  */
 
-package org.piwik.sdk;
+package org.piwik.sdk.testhelper;
 
 import android.app.Application;
 import android.content.pm.PackageInfo;
@@ -31,6 +31,6 @@ public class FullEnvTestLifeCycle extends DefaultTestLifecycle {
         for (PackageInfo pkg : oldManager.getInstalledPackages(0))
             newManager.addPackage(pkg);
         Robolectric.packageManager = newManager;
-        return new TestPiwikApplication();
+        return new PiwikTestApplication();
     }
 }

--- a/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/FullEnvTestRunner.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/FullEnvTestRunner.java
@@ -5,7 +5,7 @@
  * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
  */
 
-package org.piwik.sdk;
+package org.piwik.sdk.testhelper;
 
 import org.junit.runners.model.InitializationError;
 import org.robolectric.RobolectricTestRunner;

--- a/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/PiwikTestApplication.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/PiwikTestApplication.java
@@ -1,10 +1,11 @@
-package org.piwik.sdk;
+package org.piwik.sdk.testhelper;
 
 
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.os.Environment;
 
+import org.piwik.sdk.PiwikApplication;
 import org.robolectric.Robolectric;
 import org.robolectric.TestLifecycleApplication;
 import org.robolectric.res.builder.RobolectricPackageManager;
@@ -14,7 +15,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.lang.reflect.Method;
 
-public class TestPiwikApplication extends PiwikApplication implements TestLifecycleApplication {
+public class PiwikTestApplication extends PiwikApplication implements TestLifecycleApplication {
 
     public static final String INSTALLER_PACKAGENAME = "com.android.vending users can screw with this value !$()=%ÄÖÜ";
     public static final byte[] FAKE_APK_DATA = "this is an apk, awesome right?".getBytes();

--- a/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/TestActivity.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/testhelper/TestActivity.java
@@ -1,4 +1,4 @@
-package org.piwik.sdk;
+package org.piwik.sdk.testhelper;
 
 import android.app.Activity;
 import android.os.Bundle;

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/ChecksumTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/ChecksumTest.java
@@ -2,7 +2,7 @@ package org.piwik.sdk.tools;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.piwik.sdk.FullEnvTestRunner;
+import org.piwik.sdk.testhelper.FullEnvTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.File;

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/LogyTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/LogyTest.java
@@ -5,7 +5,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.piwik.sdk.FullEnvTestRunner;
+import org.piwik.sdk.testhelper.FullEnvTestRunner;
 import org.robolectric.annotation.Config;
 
 


### PR DESCRIPTION
So this is a new idea in progress:
I recently learned that the Google Play app sends an intent ```com.android.vending.INSTALL_REFERRER``` to the app it just installed, containing the parameters that were part of it's install url e.g. ```https://play.google.com/store/apps/details?id=com.piwik.demo&referrer=<REFERRERPARAMTERS>```.

That started the whole coding session and while add it changed a few other things.

* ```Tracker.trackAppDownload()``` previously passed the installer packagename via QueryParams.REFERRER without modifcation, no one seems to have noticed but Piwik backend ignores non URLs.... so we now prepend ```http://```
* The library now has a receiver that listens for above mentioned intent and if received, saves it into preferences.
* Because the dev can call the track download method from within the ```Application.onCreate()``` , and the broadcast receiver causes it to initialize, the actual tracking is deferred by 3 seconds if Google Play is detected as download source.
* I removed the ```Context``` parameter from the track download methods. Previously the idea was to use this as a way to track downloads of other apps. I've come to the conclusions though that this is not very clean because we can't guarantee certain functionality for other apps (access to the apk for checksum or receiving the install referrer). It's not something we should support, a dev could make his own method for this if wanted.
* I removed the ```ExtraIdentifier.INSTALLER_PACKAGENAME``` flag. It was not a very good criteria to differentiate different downloads and this is already covered by Piwiks actual Referrer section. The default flag is now ```None```.
* The download tracking is now in a sepperate class (I don't like huge classes).
* I've added syncronization to the download tracking method that should only fire once per app version, while rare it was previously possible to cause multiple calls to execute.

I've still got to add some unit tests and do some code polish.

For now i wanted some feedback and a question.

@dotsbb What do you think about the idea of catching the Google Play intent and passing the data along with ```QueryParams.REFERRER``` field? I think the idea is cool, but i fear it's too specific and a dev should decide himself if this is something he wants to add. Maybe we should not fill the REFERRER parameter at all, by default, because we can't assume this is how most of the devs would want to use it... But then again that could be argued for tracking downloads too...

@mattab Can you tell me what exactly the ```urlref``` parameter is used for when using the HTTP API? It seems the campaign section is only filled when passing the campaign names as queryparameter or part of the main ```url```. Is ```urlref``` parsed at all? There is an extra Campaign plugin in Piwik Market, but i wasn't able to install plugins on the demo server.

![testreferrerparameters](https://cloud.githubusercontent.com/assets/1439229/12575794/af016714-c40f-11e5-9e90-eff0ea8fbd58.PNG)
