### PR TITLE
Persist last used URL for future events

### DIFF
--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -113,6 +113,7 @@ public class Tracker {
         mDefaultTrackMe.set(QueryParams.LANGUAGE, DeviceHelper.getUserLanguage());
         mDefaultTrackMe.set(QueryParams.COUNTRY, DeviceHelper.getUserCountry());
         mDefaultTrackMe.set(QueryParams.VISITOR_ID, makeRandomVisitorId());
+        mDefaultTrackMe.set(QueryParams.URL_PATH, fixUrl(null, getApplicationBaseURL()));
 
         mDownloadTrackingHelper = new DownloadTrackingHelper(this);
     }
@@ -274,6 +275,7 @@ public class Tracker {
      */
     public Tracker setApplicationDomain(String domain) {
         mApplicationDomain = domain;
+        mDefaultTrackMe.set(QueryParams.URL_PATH, fixUrl(null, getApplicationBaseURL()));
         return this;
     }
 
@@ -651,15 +653,21 @@ public class Tracker {
 
         String urlPath = trackMe.get(QueryParams.URL_PATH);
         if (urlPath == null) {
-            urlPath = getApplicationBaseURL() + "/";
-        } else if (urlPath.startsWith("/")) {
-            urlPath = getApplicationBaseURL() + urlPath;
-        } else if (urlPath.startsWith("http://") || urlPath.startsWith("https://") || urlPath.startsWith("ftp://")) {
-            // URL is fine as it is
-        } else if (!urlPath.startsWith("/")) {
-            urlPath = getApplicationBaseURL() + "/" + urlPath;
+            urlPath = mDefaultTrackMe.get(QueryParams.URL_PATH);
+        } else {
+            urlPath = fixUrl(urlPath, getApplicationBaseURL());
+            mDefaultTrackMe.set(QueryParams.URL_PATH, urlPath);
         }
         trackMe.set(QueryParams.URL_PATH, urlPath);
+    }
+
+    private static String fixUrl(String url, String baseUrl) {
+        if (url == null) url = baseUrl + "/";
+
+        if (!url.startsWith("http://") && !url.startsWith("https://") && !url.startsWith("ftp://")) {
+            url = baseUrl + (url.startsWith("/") ? "" : "/") + url;
+        }
+        return url;
     }
 
     private CountDownLatch mSessionStartLatch = new CountDownLatch(0);

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -45,6 +45,29 @@ import static org.junit.Assert.assertTrue;
 public class TrackerTest extends DefaultTestCase {
 
     @Test
+    public void testLastScreenUrl() throws Exception {
+        Tracker tracker = createTracker();
+        assertNull(tracker.getLastEvent());
+
+        tracker.track(new TrackMe());
+        assertNotNull(tracker.getLastEvent());
+        QueryHashMap<String, String> queryParams = parseEventUrl(tracker.getLastEvent());
+        assertEquals(tracker.getApplicationBaseURL() + "/", queryParams.get(QueryParams.URL_PATH));
+
+        tracker.track(new TrackMe().set(QueryParams.URL_PATH, "http://some.thing.com/foo/bar"));
+        queryParams = parseEventUrl(tracker.getLastEvent());
+        assertEquals("http://some.thing.com/foo/bar", queryParams.get(QueryParams.URL_PATH));
+
+        tracker.track(new TrackMe().set(QueryParams.URL_PATH, "http://some.other/thing"));
+        queryParams = parseEventUrl(tracker.getLastEvent());
+        assertEquals("http://some.other/thing", queryParams.get(QueryParams.URL_PATH));
+
+        tracker.track(new TrackMe());
+        queryParams = parseEventUrl(tracker.getLastEvent());
+        assertEquals("http://some.other/thing", queryParams.get(QueryParams.URL_PATH));
+    }
+
+    @Test
     public void testPiwikAutoBindActivities() throws Exception {
         Application app = Robolectric.application;
         Piwik piwik = Piwik.getInstance(app);


### PR DESCRIPTION
This addresses issue #92. 
When a new `TrackMe` reaches the tracker, we check if it has `QueryParams.URL_PATH` set.

* If it has a url parameter, we check if it is valid, possibly fix it, then store it in the default `TrackMe` object the tracker maintains (`mDefaultTrackMe`).
* If it doesn't have a url parameter, we use the parameter stored in the `Tracker`'s default `TrackMe`.

`TrackMe`'s should be threadsafe meaning no crashes or bad behavior, but we are obviously still susceptible to race conditions, e.g.:

* Thread1: Track screen1.
* Thread1: Track event1.
* Thread2: Track screen2.

`event1` could be tracked with the URL from `screen2`.
I don't see how we can fix or prevent this, this is up to the developer to do correctly.

I'm preparing another PR that refactores the whole tracking API which will also adress `trackEvent` not taking a url parameter.