### PR TITLE
Added in a download tracker which you can specify the version number (for hybrid apps)

### DIFF
--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -413,6 +413,30 @@ public class Tracker {
     public Tracker trackAppDownload() {
         return trackAppDownload(mPiwik.getContext(), ExtraIdentifier.INSTALLER_PACKAGENAME);
     }
+    
+    /**
+     * Fires a download for this app once per update.
+     * The install will be tracked as:<p/>
+     * 'http://packageName:versionCode/installerPackagename'
+     * <p/>
+     * Also see {@link #trackNewAppDownload(android.content.Context, org.piwik.sdk.Tracker.ExtraIdentifier)}
+     *
+     * @return this tracker again for chaining
+     */
+    public Tracker trackAppDownload(String version) {
+        Context app = mPiwik.getContext(); 
+        try {
+            PackageInfo pkgInfo = app.getPackageManager().getPackageInfo(app.getPackageName(), 0);
+            String firedKey = "downloaded:" + pkgInfo.packageName + ":" + version;
+            if (!getSharedPreferences().getBoolean(firedKey, false)) {
+                trackNewAppDownload(app, extra);
+                getSharedPreferences().edit().putBoolean(firedKey, true).apply();
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            e.printStackTrace();
+        }
+        return this;
+    }
 
     /**
      * Fires a download for an arbitrary app once per update.

--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -425,6 +425,7 @@ public class Tracker {
      */
     public Tracker trackAppDownload(String version) {
         Context app = mPiwik.getContext(); 
+        ExtraIdentifier extra = ExtraIdentifier.INSTALLER_PACKAGENAME
         try {
             PackageInfo pkgInfo = app.getPackageManager().getPackageInfo(app.getPackageName(), 0);
             String firedKey = "downloaded:" + pkgInfo.packageName + ":" + version;

--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -425,7 +425,7 @@ public class Tracker {
      */
     public Tracker trackAppDownload(String version) {
         Context app = mPiwik.getContext(); 
-        ExtraIdentifier extra = ExtraIdentifier.INSTALLER_PACKAGENAME
+        ExtraIdentifier extra = ExtraIdentifier.INSTALLER_PACKAGENAME;
         try {
             PackageInfo pkgInfo = app.getPackageManager().getPackageInfo(app.getPackageName(), 0);
             String firedKey = "downloaded:" + pkgInfo.packageName + ":" + version;


### PR DESCRIPTION
Hi there,

Very quick and simple pull request, I just wanted to add an additional method which would allow you to specify your own version number for the tracking. This is specifically advantageous for hybrid mobile apps where you may update the app independent of rebuilding/resubmitting to the store. If there is anything else I need to do to get this accepted, let me know.

Cheers,