### PR TITLE
Changed timber version back to 4.1.2

### DIFF
--- a/piwik-sdk/build.gradle
+++ b/piwik-sdk/build.gradle
@@ -51,7 +51,7 @@ dependencies {
         mavenCentral()
     }
     compile 'com.android.support:support-annotations:23.4.0'
-    compile 'com.jakewharton.timber:timber:4.1.3-20160408.041006-2'
+    compile 'com.jakewharton.timber:timber:4.1.2'
     // Espresso
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.0')
     androidTestCompile('com.android.support.test:testing-support-lib:0.1')

--- a/piwik-sdk/src/main/AndroidManifest.xml
+++ b/piwik-sdk/src/main/AndroidManifest.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.piwik.sdk"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          package="org.piwik.sdk">
+
+    <!-- added suppression for timber since 4.1.2 has minsdk 15 because google doesn't show it in the dashboard -->
+    <uses-sdk tools:overrideLibrary="timber.log"/>
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application>
+        <!-- Suppress warning about unrestricted access to this receiver this is need to check which app store installed the app -->
         <receiver
             android:name=".InstallReferrerReceiver"
-            android:exported="true">
+            android:exported="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.android.vending.INSTALL_REFERRER"/>
             </intent-filter>


### PR DESCRIPTION
When updating to piwik 1.0.0 it would force me to update timber to a snapshot version. This should fix this so that developers using the piwik sdk don't need to forcibly be upgrade to snapshot version of timber.