### PR TITLE
Fix coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ android:
 
 script: ./gradlew :piwik-sdk:assemble :piwik-sdk:testDebugUnitTest
 
-after_success: ./gradlew :piwik-sdk:jacocoTestReport piwik-sdk:coveralls
+after_success: ./gradlew :piwik-sdk:jacocoTestReport :piwik-sdk:coveralls

--- a/piwik-sdk/build.gradle
+++ b/piwik-sdk/build.gradle
@@ -101,6 +101,10 @@ makeJar.dependsOn(clearJar, build)
 apply plugin: 'jacoco'
 apply plugin: 'com.github.kt3k.coveralls'
 
+jacoco {
+    toolVersion = "0.7.1.201405082137"
+}
+
 buildscript {
     repositories {
         mavenCentral()


### PR DESCRIPTION
[New gradle](https://github.com/piwik/piwik-sdk-android/pull/100/files#diff-c197962302397baf3a4cc36463dce5eaR8) isn't compatible with our JaCoCo config.