### PR TITLE
False price formatting

### DIFF
--- a/piwik-sdk/src/main/java/org/piwik/sdk/tools/CurrencyFormatter.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/tools/CurrencyFormatter.java
@@ -9,7 +9,6 @@ package org.piwik.sdk.tools;
 
 import android.support.annotation.Nullable;
 
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
 
@@ -19,7 +18,6 @@ public class CurrencyFormatter {
         if (cents == null) return null;
         NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.US);
         numberFormat.setMinimumFractionDigits(2);
-        DecimalFormat form = (DecimalFormat) numberFormat;
-        return form.format(cents / 100.);
+        return numberFormat.format(cents / 100.);
     }
 }

--- a/piwik-sdk/src/main/java/org/piwik/sdk/tools/CurrencyFormatter.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/tools/CurrencyFormatter.java
@@ -10,12 +10,16 @@ package org.piwik.sdk.tools;
 import android.support.annotation.Nullable;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 public class CurrencyFormatter {
     @Nullable
     public static String priceString(@Nullable Integer cents) {
         if (cents == null) return null;
-        DecimalFormat form = new DecimalFormat("0.00");
+        NumberFormat numberFormat = NumberFormat.getNumberInstance(Locale.US);
+        numberFormat.setMinimumFractionDigits(2);
+        DecimalFormat form = (DecimalFormat) numberFormat;
         return form.format(cents / 100.);
     }
 }

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/CurrencyFormatterTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/CurrencyFormatterTest.java
@@ -1,0 +1,28 @@
+package org.piwik.sdk.tools;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.piwik.sdk.testhelper.FullEnvTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+
+@Config(emulateSdk = 18, manifest = Config.NONE)
+@RunWith(FullEnvTestRunner.class)
+public class CurrencyFormatterTest {
+
+	@Test
+	public void testCurrencyFormat() throws Exception {
+		String currency = CurrencyFormatter.priceString(1000);
+		assertEquals(currency, "10.00");
+
+		currency = CurrencyFormatter.priceString(3950);
+		assertEquals(currency, "39.50");
+
+		currency = CurrencyFormatter.priceString(1);
+		assertEquals(currency, "0.01");
+
+		currency = CurrencyFormatter.priceString(25034);
+		assertEquals(currency, "250.34");
+	}
+}

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/CurrencyFormatterTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/CurrencyFormatterTest.java
@@ -11,18 +11,18 @@ import static org.junit.Assert.assertEquals;
 @RunWith(FullEnvTestRunner.class)
 public class CurrencyFormatterTest {
 
-	@Test
-	public void testCurrencyFormat() throws Exception {
-		String currency = CurrencyFormatter.priceString(1000);
-		assertEquals(currency, "10.00");
+    @Test
+    public void testCurrencyFormat() throws Exception {
+        String currency = CurrencyFormatter.priceString(1000);
+        assertEquals("10.00", currency);
 
-		currency = CurrencyFormatter.priceString(3950);
-		assertEquals(currency, "39.50");
+        currency = CurrencyFormatter.priceString(3950);
+        assertEquals("39.50", currency);
 
-		currency = CurrencyFormatter.priceString(1);
-		assertEquals(currency, "0.01");
+        currency = CurrencyFormatter.priceString(1);
+        assertEquals("0.01", currency);
 
-		currency = CurrencyFormatter.priceString(25034);
-		assertEquals(currency, "250.34");
-	}
+        currency = CurrencyFormatter.priceString(25034);
+        assertEquals("250.34", currency);
+    }
 }


### PR DESCRIPTION
When implementing the piwik library I have noticed that the prices were always 0 because CurrencyFormatter.priceString() formats prices with german locale to "10,00" and not to "10.00". Therefore the format was wrong according to the documentation and the price was not accepted from piwik. 