### PR TITLE
Addresses #110.

### DIFF
--- a/piwik-sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -46,7 +46,7 @@ public class Piwik {
      * @param siteId     (required) id of site
      * @param authToken  (optional) could be null or valid auth token.
      * @return Tracker object
-     * @throws MalformedURLException
+     * @throws RuntimeException if the supplied Piwik-Tracker URL is incompatible
      * @deprecated Use {@link #newTracker(String, int)} as there are security concerns over the authToken.
      */
     @Deprecated
@@ -58,7 +58,7 @@ public class Piwik {
      * @param trackerUrl (required) Tracking HTTP API endpoint, for example, http://your-piwik-domain.tld/piwik.php
      * @param siteId     (required) id of site
      * @return Tracker object
-     * @throws MalformedURLException
+     * @throws RuntimeException if the supplied Piwik-Tracker URL is incompatible
      */
     public synchronized Tracker newTracker(@NonNull String trackerUrl, int siteId) throws MalformedURLException {
         return new Tracker(trackerUrl, siteId, null, this);

--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -77,19 +77,21 @@ public class Tracker {
      * @param siteId    (required) id of site
      * @param authToken (optional) could be null
      * @param piwik     piwik object used to gain access to application params such as name, resolution or lang
-     * @throws MalformedURLException
+     * @throws RuntimeException if the supplied Piwik-Tracker URL is incompatible
      */
-    protected Tracker(@NonNull final String url, int siteId, String authToken, @NonNull Piwik piwik) throws MalformedURLException {
-
+    protected Tracker(@NonNull final String url, int siteId, String authToken, @NonNull Piwik piwik) {
         String checkUrl = url;
-        if (checkUrl.endsWith("piwik.php") || checkUrl.endsWith("piwik-proxy.php")) {
-            mApiUrl = new URL(checkUrl);
-        } else {
-            if (!checkUrl.endsWith("/")) {
-                checkUrl += "/";
+        try {
+            if (checkUrl.endsWith("piwik.php") || checkUrl.endsWith("piwik-proxy.php")) {
+                mApiUrl = new URL(checkUrl);
+            } else {
+                if (!checkUrl.endsWith("/")) {
+                    checkUrl += "/";
+                }
+                mApiUrl = new URL(checkUrl + "piwik.php");
             }
-            mApiUrl = new URL(checkUrl + "piwik.php");
-        }
+        } catch (MalformedURLException e) { throw new RuntimeException(e); }
+
         mPiwik = piwik;
         mSiteId = siteId;
         mAuthToken = authToken;
@@ -215,6 +217,7 @@ public class Tracker {
     /**
      * Defines if when dispatched, posted JSON must be Gzipped.
      * Need to be handle from web server side with mod_deflate/APACHE lua_zlib/NGINX.
+     *
      * @param dispatchGzipped boolean
      */
     public Tracker setDispatchGzipped(boolean dispatchGzipped) {


### PR DESCRIPTION
In most cases where devs use Piwik they likely just catch this and ignore it.
In rare cases where the tracker is instantiated from dynamic urls the dev can catch the runtime exception or do his own checking beforehand.

Closes #110
