### PR TITLE
Dont dispatch after optout

### DIFF
--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -242,16 +242,7 @@ public class Tracker {
         mDispatcher.setDispatchAfterOptout(dispatchAfterOptout);
         return this;
     }
-
-    /**
-     *
-     * @return boolean
-     */
-    public boolean getDispatchAfterOptout() {
-        return mDispatcher.getDispatchAfterOptout();
-    }
-
-
+    
     /**
      * @return in milliseconds
      */

--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -233,6 +233,17 @@ public class Tracker {
     }
 
     /**
+     * Defines if when user optout, remaining cached datas
+     * should be dispatched or not.
+     *
+     * @param dispatchAfterOptout boolean
+     */
+    public Tracker setDispatchAfterOptout(boolean dispatchAfterOptout) {
+        mDispatcher.setDispatchAfterOptout(dispatchAfterOptout);
+        return this;
+    }
+
+    /**
      * @return in milliseconds
      */
     public long getDispatchInterval() {

--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -244,6 +244,15 @@ public class Tracker {
     }
 
     /**
+     *
+     * @return boolean
+     */
+    public boolean getDispatchAfterOptout() {
+        return mDispatcher.getDispatchAfterOptout();
+    }
+
+
+    /**
      * @return in milliseconds
      */
     public long getDispatchInterval() {

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
@@ -230,7 +230,7 @@ public class Dispatcher {
 
         if (!mDryRunOutput.isEmpty()) mDryRunOutput.clear();
 
-        if (mTracker.getPiwik().isOptOut() && !mTracker.getDispatchAfterOptout() && packet.getPostData() != null){
+        if (mTracker.getPiwik().isOptOut() && mDispatchAfterOptout && packet.getPostData() != null){
             // don't send remaining datas after user is optout. Loose them.
             Timber.tag(LOGGER_TAG).d("Optout, free cache, false dispatch");
             return true;

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
@@ -230,7 +230,7 @@ public class Dispatcher {
 
         if (!mDryRunOutput.isEmpty()) mDryRunOutput.clear();
 
-        if (mTracker.getPiwik().isOptOut() && !mDispatchAfterOptout && packet.getPostData() != null){
+        if (mTracker.getPiwik().isOptOut() && !mTracker.getDispatchAfterOptout() && packet.getPostData() != null){
             // don't send remaining datas after user is optout. Loose them.
             Timber.tag(LOGGER_TAG).d("Optout, free cache, false dispatch");
             return true;

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
@@ -230,7 +230,7 @@ public class Dispatcher {
 
         if (!mDryRunOutput.isEmpty()) mDryRunOutput.clear();
 
-        if (mTracker.getPiwik().isOptOut() && mDispatchAfterOptout && packet.getPostData() != null){
+        if (mTracker.getPiwik().isOptOut() && !mDispatchAfterOptout && packet.getPostData() != null){
             // don't send remaining datas after user is optout. Loose them.
             Timber.tag(LOGGER_TAG).d("Optout, free cache, false dispatch");
             return true;

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
@@ -52,6 +52,7 @@ public class Dispatcher {
     public static final long DEFAULT_DISPATCH_INTERVAL = 120 * 1000; // 120s
     private volatile long mDispatchInterval = DEFAULT_DISPATCH_INTERVAL;
     private boolean mDispatchGzipped = false;
+    private boolean mDispatchAfterOptout = false;
     private final PacketFactory packetFactory;
     private DispatchMode mDispatchMode = DispatchMode.ALWAYS;
 
@@ -107,6 +108,20 @@ public class Dispatcher {
 
     public boolean getDispatchGzipped() {
         return mDispatchGzipped;
+    }
+
+    /**
+     * Datas should be cached before user optout. This boolean sets if when user
+     * optout, remaining cached datas should be dispatched or not.
+     *
+     * @param dispatchAfterOptout boolean
+     */
+    public void setDispatchAfterOptout(boolean dispatchAfterOptout) {
+        mDispatchAfterOptout = dispatchAfterOptout;
+    }
+
+    public boolean getDispatchAfterOptout() {
+        return mDispatchAfterOptout;
     }
 
     public void setDispatchMode(DispatchMode dispatchMode) {
@@ -215,8 +230,8 @@ public class Dispatcher {
 
         if (!mDryRunOutput.isEmpty()) mDryRunOutput.clear();
 
-        if (mTracker.getPiwik().isOptOut() && packet.getPostData() != null){
-            // don't send datas after optout
+        if (mTracker.getPiwik().isOptOut() && mDispatchAfterOptout && packet.getPostData() != null){
+            // don't send remaining datas after user is optout. Loose them.
             Timber.tag(LOGGER_TAG).d("Optout, free cache, false dispatch");
             return true;
         }

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
@@ -215,6 +215,12 @@ public class Dispatcher {
 
         if (!mDryRunOutput.isEmpty()) mDryRunOutput.clear();
 
+        if (mTracker.getPiwik().isOptOut() && packet.getPostData() != null){
+            // don't send datas after optout
+            Timber.tag(LOGGER_TAG).d("Optout, free cache, false dispatch");
+            return true;
+        }
+
         HttpURLConnection urlConnection = (HttpURLConnection) packet.openConnection();
         urlConnection.setConnectTimeout(mTimeOut);
         urlConnection.setReadTimeout(mTimeOut);

--- a/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/DispatcherTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/DispatcherTest.java
@@ -107,7 +107,7 @@ public class DispatcherTest {
         when(tracker.isDryRun()).thenReturn(false);
         when(tracker.getPiwik()).thenReturn(piwik);
         when(tracker.getPiwik().isOptOut()).thenReturn(false);
-        when(tracker.getDispatchAfterOptout()).thenReturn(false);
+        dispatcher.setDispatchAfterOptout(false);
 
         Packet packet = mock(Packet.class);
 
@@ -137,7 +137,7 @@ public class DispatcherTest {
         when(tracker.isDryRun()).thenReturn(false);
         when(tracker.getPiwik()).thenReturn(piwik);
         when(tracker.getPiwik().isOptOut()).thenReturn(true);
-        when(tracker.getDispatchAfterOptout()).thenReturn(true);
+        dispatcher.setDispatchAfterOptout(true);
 
         Packet packet = mock(Packet.class);
 
@@ -167,7 +167,7 @@ public class DispatcherTest {
         when(tracker.isDryRun()).thenReturn(false);
         when(tracker.getPiwik()).thenReturn(piwik);
         when(tracker.getPiwik().isOptOut()).thenReturn(true);
-        when(tracker.getDispatchAfterOptout()).thenReturn(false);
+        dispatcher.setDispatchAfterOptout(false);
 
         Packet packet = mock(Packet.class);
 

--- a/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/DispatcherTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/DispatcherTest.java
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.piwik.sdk.Piwik;
 import org.piwik.sdk.QueryParams;
 import org.piwik.sdk.TrackMe;
 import org.piwik.sdk.Tracker;
@@ -51,6 +52,7 @@ public class DispatcherTest {
 
     Dispatcher dispatcher;
     EventCache eventCache;
+    @Mock Piwik piwik;
     @Mock EventDiskCache eventDiskCache;
     @Mock Tracker tracker;
     @Mock Connectivity connectivity;
@@ -103,6 +105,8 @@ public class DispatcherTest {
     @Test
     public void testDispatch_gzip() throws Exception {
         when(tracker.isDryRun()).thenReturn(false);
+        when(tracker.getPiwik()).thenReturn(piwik);
+        when(tracker.getPiwik().isOptOut()).thenReturn(false);
 
         Packet packet = mock(Packet.class);
 


### PR DESCRIPTION
Hello,

When user switch to optout, remaining events that are waiting to be dispatched need to be loose.

This is a proposal.

Maybe choice should be given to dev.

From my point of view, and the legal one (in EU), when a user optout, remaining cached datas must not be sent, even if they have been collected before the change.

Thanks,

Eric