### PR TITLE
If the system supplies no nice user-agent, build one.

### DIFF
--- a/piwik-sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -12,8 +12,10 @@ import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
 
 import org.piwik.sdk.dispatcher.DispatcherFactory;
+import org.piwik.sdk.tools.BuildInfo;
 import org.piwik.sdk.tools.Checksum;
 import org.piwik.sdk.tools.DeviceHelper;
+import org.piwik.sdk.tools.PropertySource;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -104,6 +106,6 @@ public class Piwik {
     }
 
     DeviceHelper getDeviceHelper() {
-        return new DeviceHelper(mContext);
+        return new DeviceHelper(mContext, new PropertySource(), new BuildInfo());
     }
 }

--- a/piwik-sdk/src/main/java/org/piwik/sdk/tools/BuildInfo.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/tools/BuildInfo.java
@@ -1,0 +1,18 @@
+package org.piwik.sdk.tools;
+
+
+import android.os.Build;
+
+public class BuildInfo {
+    public String getRelease() {
+        return Build.VERSION.RELEASE;
+    }
+
+    public String getModel() {
+        return Build.MODEL;
+    }
+
+    public String getBuildId() {
+        return Build.ID;
+    }
+}

--- a/piwik-sdk/src/main/java/org/piwik/sdk/tools/DeviceHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/tools/DeviceHelper.java
@@ -26,8 +26,14 @@ import timber.log.Timber;
 public class DeviceHelper {
     private static final String LOGGER_TAG = Piwik.LOGGER_PREFIX + "DeviceHelper";
     private final Context mContext;
+    private final PropertySource mPropertySource;
+    private final BuildInfo mBuildInfo;
 
-    public DeviceHelper(Context context) {mContext = context;}
+    public DeviceHelper(Context context, PropertySource propertySource, BuildInfo buildInfo) {
+        mContext = context;
+        mPropertySource = propertySource;
+        mBuildInfo = buildInfo;
+    }
 
     /**
      * Returns user language
@@ -44,7 +50,19 @@ public class DeviceHelper {
      * @return well formatted user agent
      */
     public String getUserAgent() {
-        return System.getProperty("http.agent");
+        String httpAgent = mPropertySource.getHttpAgent();
+        if (httpAgent == null || httpAgent.startsWith("Apache-HttpClient/UNAVAILABLE (java")) {
+            String dalvik = mPropertySource.getJVMVersion();
+            if (dalvik == null) dalvik = "0.0.0";
+            String android = mBuildInfo.getRelease();
+            String model = mBuildInfo.getModel();
+            String build = mBuildInfo.getBuildId();
+            httpAgent = String.format(Locale.US,
+                    "Dalvik/%s (Linux; U; Android %s; %s Build/%s)",
+                    dalvik, android, model, build
+            );
+        }
+        return httpAgent;
     }
 
     /**

--- a/piwik-sdk/src/main/java/org/piwik/sdk/tools/PropertySource.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/tools/PropertySource.java
@@ -1,0 +1,21 @@
+package org.piwik.sdk.tools;
+
+
+import android.support.annotation.Nullable;
+
+public class PropertySource {
+    @Nullable
+    public String getHttpAgent() {
+        return getSystemProperty("http.agent");
+    }
+
+    @Nullable
+    public String getJVMVersion() {
+        return getSystemProperty("java.vm.version");
+    }
+
+    @Nullable
+    public String getSystemProperty(String key) {
+        return System.getProperty(key);
+    }
+}

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/BuildInfoTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/BuildInfoTest.java
@@ -1,0 +1,34 @@
+package org.piwik.sdk.tools;
+
+import android.os.Build;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class BuildInfoTest {
+
+    private BuildInfo mBuildInfo;
+
+    @Before
+    public void setup() {
+        mBuildInfo = new BuildInfo();
+    }
+
+    @Test
+    public void testGetRelease() {
+        assertEquals(Build.VERSION.RELEASE, mBuildInfo.getRelease());
+    }
+
+    @Test
+    public void testGetModel() {
+        assertEquals(Build.MODEL, mBuildInfo.getModel());
+    }
+
+    @Test
+    public void testGetBuildId() {
+        assertEquals(Build.ID, mBuildInfo.getBuildId());
+    }
+}

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/DeviceHelperTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/DeviceHelperTest.java
@@ -1,0 +1,49 @@
+package org.piwik.sdk.tools;
+
+
+import android.content.Context;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DeviceHelperTest {
+    @Mock PropertySource mPropertySource;
+    @Mock BuildInfo mBuildInfo;
+    @Mock Context mContext;
+    private DeviceHelper mDeviceHelper;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(mBuildInfo.getBuildId()).thenReturn("ABCDEF");
+        when(mBuildInfo.getModel()).thenReturn("UnitTest");
+        when(mBuildInfo.getRelease()).thenReturn("8.0.0");
+        when(mPropertySource.getJVMVersion()).thenReturn("2.2.0");
+        mDeviceHelper = new DeviceHelper(mContext, mPropertySource, mBuildInfo);
+    }
+
+    @Test
+    public void testGetHttpAgent_normal() {
+        when(mPropertySource.getHttpAgent()).thenReturn("testagent");
+        assertEquals("testagent", mDeviceHelper.getUserAgent());
+    }
+
+    @Test
+    public void testGetHttpAgent_badAgent() {
+        when(mPropertySource.getHttpAgent()).thenReturn("Apache-HttpClient/UNAVAILABLE (java 1.4)");
+        assertEquals("Dalvik/2.2.0 (Linux; U; Android 8.0.0; UnitTest Build/ABCDEF)", mDeviceHelper.getUserAgent());
+        verify(mBuildInfo).getBuildId();
+        verify(mBuildInfo).getModel();
+        verify(mBuildInfo).getRelease();
+        verify(mPropertySource).getJVMVersion();
+
+        when(mPropertySource.getJVMVersion()).thenReturn(null);
+        assertEquals("Dalvik/0.0.0 (Linux; U; Android 8.0.0; UnitTest Build/ABCDEF)", mDeviceHelper.getUserAgent());
+    }
+}

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/PropertySourceTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/PropertySourceTest.java
@@ -1,0 +1,28 @@
+package org.piwik.sdk.tools;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+
+public class PropertySourceTest {
+    @Test
+    public void testGetHttpAgent() {
+        PropertySource propertySource = spy(new PropertySource());
+        propertySource.getHttpAgent();
+        verify(propertySource).getSystemProperty("http.agent");
+
+        assertEquals(propertySource.getHttpAgent(), propertySource.getSystemProperty("http.agent"));
+    }
+
+    @Test
+    public void testGetJVMVersion() {
+        PropertySource propertySource = spy(new PropertySource());
+        propertySource.getJVMVersion();
+        verify(propertySource).getSystemProperty("java.vm.version");
+
+        assertEquals(propertySource.getJVMVersion(), propertySource.getSystemProperty("java.vm.version"));
+    }
+}


### PR DESCRIPTION
I collected ~750k unknown devices, out of those 10% were unknown due to supplying no good user agent.
This PR adds user agent generation if none is available.
The agent is analog to most of the agents I've seen during collection and should hopefully work nicely with piwiks device-detector module.

The other 90% will require regex improvements.
A few popular ones are already covered in https://github.com/piwik/device-detector/pull/5586
The rest will require lots of work 😦, see https://github.com/piwik/device-detector/issues/5585

Closes #152.