### PR TITLE
Offline cache bug fixes

### DIFF
--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Dispatcher.java
@@ -156,9 +156,7 @@ public class Dispatcher {
                     mSleepToken.tryAcquire(mDispatchInterval, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {Timber.tag(LOGGER_TAG).e(e); }
 
-                boolean connected = isConnected();
-                mEventCache.updateState(connected);
-                if (connected) {
+                if (mEventCache.updateState(isConnected())) {
                     int count = 0;
                     List<Event> drainedEvents = new ArrayList<>();
                     mEventCache.drainTo(drainedEvents);

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/EventCache.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/EventCache.java
@@ -36,7 +36,7 @@ public class EventCache {
         return mQueue.isEmpty() && mDiskCache.isEmpty();
     }
 
-    public void updateState(boolean online) {
+    public boolean updateState(boolean online) {
         if (online) {
             final List<Event> uncache = mDiskCache.uncache();
             ListIterator<Event> it = uncache.listIterator(uncache.size());
@@ -51,6 +51,7 @@ public class EventCache {
             mDiskCache.cache(toCache);
             Timber.tag(TAG).d("Switched state to OFFLINE, caching %d events to disk.", toCache.size());
         }
+        return online && !mQueue.isEmpty();
     }
 
     public void requeue(List<Event> events) {

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Packet.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/Packet.java
@@ -8,7 +8,6 @@ package org.piwik.sdk.dispatcher;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
 
 import org.json.JSONObject;
 
@@ -19,7 +18,7 @@ import java.net.URLConnection;
 /**
  * Data that can be send to the backend API via the Dispatcher
  */
-@VisibleForTesting
+
 public class Packet {
     private final URL mTargetURL;
     private final JSONObject mPostData;


### PR DESCRIPTION
* We only recached requests if there was an exception and we only increased the event count to determine what needs to be cached if the transmission was succesfull. If we failed to transmit without an exception, but then were able to transmit, and then got an exception we would cache the wrong data.
* Treat dispatching issues, i.e. server returns non-OK status code, as failure. Stop dispatch and recache events, e.g. if the server is doing a reboot or having technical issues or what ever.
* When updating the event cache with `online`/`offline` have it return a `true` if we are online and have cached events, otherwise `false` this way we avoid unnecessarily running through the next few lines of code, only to end up with an empty list that won't be iterated. Theoretically this would make us more prone to raceconditions if new event are added during that time, but as we syncronize the cache-check and `launch()` there shouldn't be any such racecondition.