### PR TITLE
Allow custom identifiers when tracking downloads.

### DIFF
--- a/exampleapp/src/main/java/com/piwik/demo/DemoApp.java
+++ b/exampleapp/src/main/java/com/piwik/demo/DemoApp.java
@@ -48,7 +48,7 @@ public class DemoApp extends PiwikApplication {
 
         // Track this app install, this will only trigger once per app version.
         // i.e. "http://com.piwik.demo:1/185DECB5CFE28FDB2F45887022D668B4"
-        TrackHelper.track().download().identifier(DownloadTracker.Extra.APK_CHECKSUM).with(getTracker());
+        TrackHelper.track().download().identifier(new DownloadTracker.Extra.ApkChecksum(this)).with(getTracker());
         // Alternative:
         // i.e. "http://com.piwik.demo:1/com.android.vending"
         // getTracker().download();

--- a/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
@@ -354,12 +354,10 @@ public class TrackHelper {
      * {@link Download#force()}
      * <p class="note">
      * Resulting download url:<p>
-     * Case {@link DownloadTracker.Extra#APK_CHECKSUM}:<br>
+     * Case {@link org.piwik.sdk.extra.DownloadTracker.Extra.ApkChecksum}:<br>
      * http://packageName:versionCode/apk-md5-checksum<br>
-     * Usually the installer-packagename is something like "com.android.vending" (Google Play),
-     * but users can modify this value, don't be surprised by some random values.<p>
      * <p>
-     * Case {@link DownloadTracker.Extra#NONE}:<br>
+     * Case {@link org.piwik.sdk.extra.DownloadTracker.Extra.None}:<br>
      * http://packageName:versionCode<p>
      *
      * @return this object, to chain calls.
@@ -375,7 +373,7 @@ public class TrackHelper {
     public static class Download {
         private DownloadTracker mDownloadTracker;
         private final TrackHelper mBaseBuilder;
-        private DownloadTracker.Extra mExtra = DownloadTracker.Extra.NONE;
+        private DownloadTracker.Extra mExtra = new DownloadTracker.Extra.None();
         private boolean mForced = false;
         private String mVersion;
 
@@ -387,7 +385,7 @@ public class TrackHelper {
         /**
          * Sets the identifier type for this download
          *
-         * @param identifier {@link DownloadTracker.Extra#APK_CHECKSUM} or {@link DownloadTracker.Extra#NONE}
+         * @param identifier {@link org.piwik.sdk.extra.DownloadTracker.Extra.ApkChecksum} or {@link org.piwik.sdk.extra.DownloadTracker.Extra.None}
          * @return this object, to chain calls.
          */
         public Download identifier(DownloadTracker.Extra identifier) {
@@ -421,11 +419,8 @@ public class TrackHelper {
         public void with(Tracker tracker) {
             if (mDownloadTracker == null) mDownloadTracker = new DownloadTracker(tracker);
             if (mVersion != null) mDownloadTracker.setVersion(mVersion);
-            if (mForced) {
-                mDownloadTracker.trackNewAppDownload(mBaseBuilder.mBaseTrackMe, mExtra);
-            } else {
-                mDownloadTracker.trackOnce(mBaseBuilder.mBaseTrackMe, mExtra);
-            }
+            if (mForced) mDownloadTracker.trackNewAppDownload(mBaseBuilder.mBaseTrackMe, mExtra);
+            else mDownloadTracker.trackOnce(mBaseBuilder.mBaseTrackMe, mExtra);
         }
     }
 

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/DownloadTrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/DownloadTrackerTest.java
@@ -59,12 +59,12 @@ public class DownloadTrackerTest {
     @Test
     public void testTrackAppDownload() throws Exception {
         DownloadTracker downloadTracker = new DownloadTracker(mTracker);
-        downloadTracker.trackOnce(new TrackMe(), DownloadTracker.Extra.NONE);
+        downloadTracker.trackOnce(new TrackMe(), new DownloadTracker.Extra.None());
         verify(mTracker).track(mCaptor.capture());
         checkNewAppDownload(mCaptor.getValue());
 
         // track only once
-        downloadTracker.trackOnce(new TrackMe(), DownloadTracker.Extra.NONE);
+        downloadTracker.trackOnce(new TrackMe(), new DownloadTracker.Extra.None());
         verify(mTracker, times(1)).track(mCaptor.capture());
     }
 
@@ -85,7 +85,7 @@ public class DownloadTrackerTest {
         }
 
         DownloadTracker downloadTracker = new DownloadTracker(mTracker);
-        downloadTracker.trackNewAppDownload(new TrackMe(), DownloadTracker.Extra.APK_CHECKSUM);
+        downloadTracker.trackNewAppDownload(new TrackMe(), new DownloadTracker.Extra.ApkChecksum(mContext));
         Thread.sleep(100); // APK checksum happens off thread
         verify(mTracker).track(mCaptor.capture());
         checkNewAppDownload(mCaptor.getValue());
@@ -96,7 +96,7 @@ public class DownloadTrackerTest {
         assertEquals(FAKE_APK_DATA_MD5, m.group(3));
         assertEquals("http://installer", mCaptor.getValue().get(QueryParams.REFERRER));
 
-        downloadTracker.trackNewAppDownload(new TrackMe(), DownloadTracker.Extra.NONE);
+        downloadTracker.trackNewAppDownload(new TrackMe(), new DownloadTracker.Extra.None());
         verify(mTracker, times(2)).track(mCaptor.capture());
         checkNewAppDownload(mCaptor.getValue());
         String downloadParams = mCaptor.getValue().get(QueryParams.DOWNLOAD);
@@ -117,7 +117,7 @@ public class DownloadTrackerTest {
     @Test
     public void testTrackReferrer() throws Exception {
         DownloadTracker downloadTracker = new DownloadTracker(mTracker);
-        downloadTracker.trackNewAppDownload(new TrackMe(), DownloadTracker.Extra.NONE);
+        downloadTracker.trackNewAppDownload(new TrackMe(), new DownloadTracker.Extra.None());
         verify(mTracker).track(mCaptor.capture());
         checkNewAppDownload(mCaptor.getValue());
         String downloadParams = mCaptor.getValue().get(QueryParams.DOWNLOAD);
@@ -130,7 +130,7 @@ public class DownloadTrackerTest {
         assertEquals("http://installer", mCaptor.getValue().get(QueryParams.REFERRER));
 
         when(mPackageManager.getInstallerPackageName(anyString())).thenReturn(null);
-        downloadTracker.trackNewAppDownload(new TrackMe(), DownloadTracker.Extra.NONE);
+        downloadTracker.trackNewAppDownload(new TrackMe(), new DownloadTracker.Extra.None());
         verify(mTracker, times(2)).track(mCaptor.capture());
         checkNewAppDownload(mCaptor.getValue());
         m = REGEX_DOWNLOADTRACK.matcher(mCaptor.getValue().get(QueryParams.DOWNLOAD));
@@ -146,7 +146,7 @@ public class DownloadTrackerTest {
     public void testTrackNewAppDownloadWithVersion() throws Exception {
         DownloadTracker downloadTracker = new DownloadTracker(mTracker);
         downloadTracker.setVersion("2");
-        downloadTracker.trackOnce(new TrackMe(), DownloadTracker.Extra.NONE);
+        downloadTracker.trackOnce(new TrackMe(), new DownloadTracker.Extra.None());
         verify(mTracker).track(mCaptor.capture());
         checkNewAppDownload(mCaptor.getValue());
         Matcher m = REGEX_DOWNLOADTRACK.matcher(mCaptor.getValue().get(QueryParams.DOWNLOAD));
@@ -156,11 +156,11 @@ public class DownloadTrackerTest {
         assertEquals("2", downloadTracker.getVersion());
         assertEquals("http://installer", mCaptor.getValue().get(QueryParams.REFERRER));
 
-        downloadTracker.trackOnce(new TrackMe(), DownloadTracker.Extra.NONE);
+        downloadTracker.trackOnce(new TrackMe(), new DownloadTracker.Extra.None());
         verify(mTracker, times(1)).track(mCaptor.capture());
 
         downloadTracker.setVersion(null);
-        downloadTracker.trackOnce(new TrackMe(), DownloadTracker.Extra.NONE);
+        downloadTracker.trackOnce(new TrackMe(), new DownloadTracker.Extra.None());
         verify(mTracker, times(2)).track(mCaptor.capture());
         checkNewAppDownload(mCaptor.getValue());
         m = REGEX_DOWNLOADTRACK.matcher(mCaptor.getValue().get(QueryParams.DOWNLOAD));

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/DownloadTrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/DownloadTrackerTest.java
@@ -51,6 +51,7 @@ public class DownloadTrackerTest {
 
         mPackageInfo = new PackageInfo();
         mPackageInfo.versionCode = 123;
+        mPackageInfo.packageName = "package";
         //noinspection WrongConstant
         when(mPackageManager.getPackageInfo(anyString(), anyInt())).thenReturn(mPackageInfo);
         when(mPackageManager.getInstallerPackageName("package")).thenReturn("installer");

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/TrackHelperTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/TrackHelperTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -94,15 +93,15 @@ public class TrackHelperTest {
     @Test
     public void testDownloadTrackChecksum() throws Exception {
         DownloadTracker downloadTracker = mock(DownloadTracker.class);
-        track().download(downloadTracker).identifier(DownloadTracker.Extra.APK_CHECKSUM).with(mTracker);
-        verify(downloadTracker).trackOnce(any(TrackMe.class), eq(DownloadTracker.Extra.APK_CHECKSUM));
+        track().download(downloadTracker).identifier(new DownloadTracker.Extra.ApkChecksum(mContext)).with(mTracker);
+        verify(downloadTracker).trackOnce(any(TrackMe.class), any(DownloadTracker.Extra.ApkChecksum.class));
     }
 
     @Test
     public void testDownloadTrackForced() throws Exception {
         DownloadTracker downloadTracker = mock(DownloadTracker.class);
         track().download(downloadTracker).force().with(mTracker);
-        verify(downloadTracker).trackNewAppDownload(any(TrackMe.class), eq(DownloadTracker.Extra.NONE));
+        verify(downloadTracker).trackNewAppDownload(any(TrackMe.class), any(DownloadTracker.Extra.None.class));
     }
 
     @Test


### PR DESCRIPTION
Make it possible to create custom extra identifiers for download tracking.

Instead of passing enums we pass objects that implement the `Extra` interface.

Now we can also move our `Extra.Checksum` code out of the core download tracker code into an `ApkChecksum extends Extra`, much cleaner 😄 .

My idea was that I wanted to use the checksum as extra identifier, but also reuse that checksum somewhere else so it's not calculated twice. With this change it is now possible to do that.