### PR TITLE
TrackHelper using exceptions instead of returning null.

### DIFF
--- a/piwik-sdk/build.gradle
+++ b/piwik-sdk/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 
-def versionMajor = 2
+def versionMajor = 3
 def versionMinor = 0
 def versionPatch = 0
 def myVersionCode = versionMajor * 10000 + versionMinor * 100 + versionPatch

--- a/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
@@ -54,6 +54,9 @@ public class TrackHelper {
             return mBaseBuilder.mBaseTrackMe;
         }
 
+        /**
+         * May throw an {@link IllegalArgumentException} if the TrackMe was build with incorrect arguments.
+         */
         public abstract TrackMe build();
 
         public void with(PiwikApplication piwikApplication) {
@@ -63,6 +66,27 @@ public class TrackHelper {
         public void with(Tracker tracker) {
             TrackMe trackMe = build();
             tracker.track(trackMe);
+        }
+
+        public boolean safelyWith(PiwikApplication piwikApplication) {
+            return safelyWith(piwikApplication.getTracker());
+        }
+
+        /**
+         * {@link #build()} can throw an exception on illegal arguments.
+         * This can be used to avoid crashes when using dynamic {@link TrackMe} arguments.
+         *
+         * @return false if an error occured, true if the TrackMe has been submitted to be dispatched.
+         */
+        public boolean safelyWith(Tracker tracker) {
+            try {
+                TrackMe trackMe = build();
+                tracker.track(trackMe);
+            } catch (IllegalArgumentException e) {
+                Timber.e(e);
+                return false;
+            }
+            return true;
         }
     }
 

--- a/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import org.piwik.sdk.Piwik;
@@ -57,11 +56,11 @@ public class TrackHelper {
 
         public abstract TrackMe build();
 
-        public void with(@NonNull PiwikApplication piwikApplication) {
+        public void with(PiwikApplication piwikApplication) {
             with(piwikApplication.getTracker());
         }
 
-        public void with(@NonNull Tracker tracker) {
+        public void with(Tracker tracker) {
             TrackMe trackMe = build();
             tracker.track(trackMe);
         }
@@ -167,18 +166,18 @@ public class TrackHelper {
      *                 and the action is a button click.
      * @return an object that allows addition of further details.
      */
-    public EventBuilder event(@NonNull String category, @NonNull String action) {
+    public EventBuilder event(String category, String action) {
         return new EventBuilder(this, category, action);
     }
 
     public static class EventBuilder extends BaseEvent {
-        @NonNull private final String mCategory;
-        @NonNull private final String mAction;
+        private final String mCategory;
+        private final String mAction;
         private String mPath;
         private String mName;
         private Float mValue;
 
-        EventBuilder(TrackHelper builder, @NonNull String category, @NonNull String action) {
+        EventBuilder(TrackHelper builder, String category, String action) {
             super(builder);
             mCategory = category;
             mAction = action;
@@ -433,7 +432,7 @@ public class TrackHelper {
      *
      * @param contentName The name of the content. For instance 'Ad Foo Bar'
      */
-    public ContentImpression impression(@NonNull String contentName) {
+    public ContentImpression impression(String contentName) {
         return new ContentImpression(this, contentName);
     }
 
@@ -483,7 +482,7 @@ public class TrackHelper {
      * @param contentInteraction The name of the interaction with the content. For instance a 'click'
      * @param contentName        The name of the content. For instance 'Ad Foo Bar'
      */
-    public ContentInteraction interaction(@NonNull String contentName, @NonNull String contentInteraction) {
+    public ContentInteraction interaction(String contentName, String contentInteraction) {
         return new ContentInteraction(this, contentName, contentInteraction);
     }
 

--- a/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
@@ -97,9 +97,6 @@ public class TrackHelper {
         Screen(TrackHelper baseBuilder, String path) {
             super(baseBuilder);
             mPath = path;
-            if (mPath == null) {
-                throw new IllegalArgumentException("Screen tracking requires a non-empty path");
-            }
         }
 
         /**
@@ -139,6 +136,10 @@ public class TrackHelper {
 
         @Override
         public TrackMe build() {
+            if (mPath == null) {
+                throw new IllegalArgumentException("Screen tracking requires a non-empty path");
+            }
+
             final TrackMe trackMe = new TrackMe(getBaseTrackMe())
                     .set(QueryParams.URL_PATH, mPath)
                     .set(QueryParams.ACTION_NAME, mTitle);
@@ -243,9 +244,6 @@ public class TrackHelper {
         Goal(TrackHelper baseBuilder, int idGoal) {
             super(baseBuilder);
             mIdGoal = idGoal;
-            if (mIdGoal < 0) {
-                throw new IllegalArgumentException("Goal id needs to be >=0");
-            }
         }
 
         /**
@@ -260,6 +258,10 @@ public class TrackHelper {
 
         @Override
         public TrackMe build() {
+            if (mIdGoal < 0) {
+                throw new IllegalArgumentException("Goal id needs to be >=0");
+            }
+
             TrackMe trackMe = new TrackMe(getBaseTrackMe()).set(QueryParams.GOAL_ID, mIdGoal);
             if (mRevenue != null) trackMe.set(QueryParams.REVENUE, mRevenue);
             return trackMe;
@@ -282,16 +284,17 @@ public class TrackHelper {
         Outlink(TrackHelper baseBuilder, URL url) {
             super(baseBuilder);
             mURL = url;
-            if (url == null || url.toExternalForm().length() == 0) {
+        }
+
+        @Override
+        public TrackMe build() {
+            if (mURL == null || mURL.toExternalForm().length() == 0) {
                 throw new IllegalArgumentException("Outlink tracking requires a non-empty URL");
             }
             if (!mURL.getProtocol().equals("http") && !mURL.getProtocol().equals("https") && !mURL.getProtocol().equals("ftp")) {
                 throw new IllegalArgumentException("Only http|https|ftp is supported for outlinks");
             }
-        }
 
-        @Override
-        public TrackMe build() {
             return new TrackMe(getBaseTrackMe())
                     .set(QueryParams.LINK, mURL.toExternalForm())
                     .set(QueryParams.URL_PATH, mURL.toExternalForm());
@@ -442,9 +445,6 @@ public class TrackHelper {
         ContentImpression(TrackHelper baseBuilder, String contentName) {
             super(baseBuilder);
             mContentName = contentName;
-            if (mContentName == null || mContentName.length() == 0) {
-                throw new IllegalArgumentException("Tracking content impressions requires a non-empty content-name");
-            }
         }
 
         /**
@@ -465,6 +465,9 @@ public class TrackHelper {
 
         @Override
         public TrackMe build() {
+            if (mContentName == null || mContentName.length() == 0) {
+                throw new IllegalArgumentException("Tracking content impressions requires a non-empty content-name");
+            }
             return new TrackMe(getBaseTrackMe())
                     .set(QueryParams.CONTENT_NAME, mContentName)
                     .set(QueryParams.CONTENT_PIECE, mContentPiece)
@@ -494,12 +497,6 @@ public class TrackHelper {
             super(baseBuilder);
             mContentName = contentName;
             mInteraction = interaction;
-            if (mContentName == null || mContentName.length() == 0) {
-                throw new IllegalArgumentException("Content name needs to be non-empty");
-            }
-            if (mInteraction == null || mInteraction.length() == 0) {
-                throw new IllegalArgumentException("Interaction name needs to be non-empty");
-            }
         }
 
         /**
@@ -520,6 +517,13 @@ public class TrackHelper {
 
         @Override
         public TrackMe build() {
+            if (mContentName == null || mContentName.length() == 0) {
+                throw new IllegalArgumentException("Content name needs to be non-empty");
+            }
+            if (mInteraction == null || mInteraction.length() == 0) {
+                throw new IllegalArgumentException("Interaction name needs to be non-empty");
+            }
+
             return new TrackMe(getBaseTrackMe())
                     .set(QueryParams.CONTENT_NAME, mContentName)
                     .set(QueryParams.CONTENT_PIECE, mContentPiece)

--- a/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/extra/TrackHelper.java
@@ -55,7 +55,6 @@ public class TrackHelper {
             return mBaseBuilder.mBaseTrackMe;
         }
 
-        @Nullable
         public abstract TrackMe build();
 
         public void with(@NonNull PiwikApplication piwikApplication) {
@@ -64,7 +63,7 @@ public class TrackHelper {
 
         public void with(@NonNull Tracker tracker) {
             TrackMe trackMe = build();
-            if (trackMe != null) tracker.track(trackMe);
+            tracker.track(trackMe);
         }
     }
 
@@ -98,6 +97,9 @@ public class TrackHelper {
         Screen(TrackHelper baseBuilder, String path) {
             super(baseBuilder);
             mPath = path;
+            if (mPath == null) {
+                throw new IllegalArgumentException("Screen tracking requires a non-empty path");
+            }
         }
 
         /**
@@ -135,10 +137,8 @@ public class TrackHelper {
             return this;
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
-            if (mPath == null) return null;
             final TrackMe trackMe = new TrackMe(getBaseTrackMe())
                     .set(QueryParams.URL_PATH, mPath)
                     .set(QueryParams.ACTION_NAME, mTitle);
@@ -210,7 +210,6 @@ public class TrackHelper {
             return this;
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
             TrackMe trackMe = new TrackMe(getBaseTrackMe())
@@ -244,6 +243,9 @@ public class TrackHelper {
         Goal(TrackHelper baseBuilder, int idGoal) {
             super(baseBuilder);
             mIdGoal = idGoal;
+            if (mIdGoal < 0) {
+                throw new IllegalArgumentException("Goal id needs to be >=0");
+            }
         }
 
         /**
@@ -256,10 +258,8 @@ public class TrackHelper {
             return this;
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
-            if (mIdGoal < 0) return null;
             TrackMe trackMe = new TrackMe(getBaseTrackMe()).set(QueryParams.GOAL_ID, mIdGoal);
             if (mRevenue != null) trackMe.set(QueryParams.REVENUE, mRevenue);
             return trackMe;
@@ -282,14 +282,16 @@ public class TrackHelper {
         Outlink(TrackHelper baseBuilder, URL url) {
             super(baseBuilder);
             mURL = url;
+            if (url == null || url.toExternalForm().length() == 0) {
+                throw new IllegalArgumentException("Outlink tracking requires a non-empty URL");
+            }
+            if (!mURL.getProtocol().equals("http") && !mURL.getProtocol().equals("https") && !mURL.getProtocol().equals("ftp")) {
+                throw new IllegalArgumentException("Only http|https|ftp is supported for outlinks");
+            }
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
-            if (!mURL.getProtocol().equals("http") && !mURL.getProtocol().equals("https") && !mURL.getProtocol().equals("ftp")) {
-                return null;
-            }
             return new TrackMe(getBaseTrackMe())
                     .set(QueryParams.LINK, mURL.toExternalForm())
                     .set(QueryParams.URL_PATH, mURL.toExternalForm());
@@ -337,7 +339,6 @@ public class TrackHelper {
             return this;
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
             TrackMe trackMe = new TrackMe(getBaseTrackMe())
@@ -441,6 +442,9 @@ public class TrackHelper {
         ContentImpression(TrackHelper baseBuilder, String contentName) {
             super(baseBuilder);
             mContentName = contentName;
+            if (mContentName == null || mContentName.length() == 0) {
+                throw new IllegalArgumentException("Tracking content impressions requires a non-empty content-name");
+            }
         }
 
         /**
@@ -459,10 +463,8 @@ public class TrackHelper {
             return this;
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
-            if (mContentName == null || mContentName.length() == 0) return null;
             return new TrackMe(getBaseTrackMe())
                     .set(QueryParams.CONTENT_NAME, mContentName)
                     .set(QueryParams.CONTENT_PIECE, mContentPiece)
@@ -492,6 +494,12 @@ public class TrackHelper {
             super(baseBuilder);
             mContentName = contentName;
             mInteraction = interaction;
+            if (mContentName == null || mContentName.length() == 0) {
+                throw new IllegalArgumentException("Content name needs to be non-empty");
+            }
+            if (mInteraction == null || mInteraction.length() == 0) {
+                throw new IllegalArgumentException("Interaction name needs to be non-empty");
+            }
         }
 
         /**
@@ -510,11 +518,8 @@ public class TrackHelper {
             return this;
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
-            if (mContentName == null || mContentName.length() == 0) return null;
-            if (mInteraction == null || mInteraction.length() == 0) return null;
             return new TrackMe(getBaseTrackMe())
                     .set(QueryParams.CONTENT_NAME, mContentName)
                     .set(QueryParams.CONTENT_PIECE, mContentPiece)
@@ -551,7 +556,6 @@ public class TrackHelper {
             return this;
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
             if (mEcommerceItems == null) mEcommerceItems = new EcommerceItems();
@@ -629,7 +633,6 @@ public class TrackHelper {
             return this;
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
             if (mEcommerceItems == null) mEcommerceItems = new EcommerceItems();
@@ -688,7 +691,6 @@ public class TrackHelper {
             return this;
         }
 
-        @Nullable
         @Override
         public TrackMe build() {
             String className;

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -307,18 +307,15 @@ public class TrackerTest {
         verify(mDispatcher).submit(mCaptor.capture());
         assertEquals("1", mCaptor.getValue().get(QueryParams.SESSION_START));
 
-        TrackHelper.track().screen("").with(mTracker);
-        verify(mDispatcher, times(2)).submit(mCaptor.capture());
-        assertEquals(null, mCaptor.getValue().get(QueryParams.SESSION_START));
-
-        TrackHelper.track().screen("").with(mTracker);
-        verify(mDispatcher, times(3)).submit(mCaptor.capture());
-        assertEquals(null, mCaptor.getValue().get(QueryParams.SESSION_START));
-
         mTracker.startNewSession();
         TrackHelper.track().screen("").with(mTracker);
-        verify(mDispatcher, times(4)).submit(mCaptor.capture());
+        verify(mDispatcher, times(2)).submit(mCaptor.capture());
         assertEquals("1", mCaptor.getValue().get(QueryParams.SESSION_START));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetNewSession_invalid_argument() throws Exception {
+        TrackHelper.track().screen((String) null);
     }
 
     @Test

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -313,11 +313,6 @@ public class TrackerTest {
         assertEquals("1", mCaptor.getValue().get(QueryParams.SESSION_START));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetNewSession_invalid_argument() throws Exception {
-        TrackHelper.track().screen((String) null);
-    }
-
     @Test
     public void testSetNewSessionRaceCondition() throws Exception {
         for (int retry = 0; retry < 5; retry++) {

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/TrackHelperTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/TrackHelperTest.java
@@ -15,6 +15,7 @@ import org.piwik.sdk.QueryParams;
 import org.piwik.sdk.TrackMe;
 import org.piwik.sdk.Tracker;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Locale;
 import java.util.UUID;
@@ -29,7 +30,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,9 +68,6 @@ public class TrackHelperTest {
 
     @Test
     public void testOutlink() throws Exception {
-        track().outlink(new URL("file://mount/sdcard/something")).with(mTracker);
-        verify(mTracker, never()).track(mCaptor.capture());
-
         URL valid = new URL("https://foo.bar");
         track().outlink(valid).with(mTracker);
         verify(mTracker).track(mCaptor.capture());
@@ -88,6 +85,11 @@ public class TrackHelperTest {
         verify(mTracker, times(3)).track(mCaptor.capture());
         assertEquals(valid.toExternalForm(), mCaptor.getValue().get(QueryParams.LINK));
         assertEquals(valid.toExternalForm(), mCaptor.getValue().get(QueryParams.URL_PATH));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testOutlink_invalid_url() throws MalformedURLException {
+        track().outlink(new URL("file://mount/sdcard/something"));
     }
 
     @Test
@@ -291,6 +293,11 @@ public class TrackHelperTest {
         assertEquals(mCaptor.getValue().get(QueryParams.GOAL_ID), "1");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testTrackGoal_invalid_id() throws Exception {
+        track().goal(-1).revenue(100f);
+    }
+
     @Test
     public void testTrackSiteSearch() throws Exception {
         track().search("keyword").category("category").count(1337).with(mTracker);
@@ -315,12 +322,6 @@ public class TrackHelperTest {
 
         assertEquals("1", mCaptor.getValue().get(QueryParams.GOAL_ID));
         assertTrue(100f == Float.valueOf(mCaptor.getValue().get(QueryParams.REVENUE)));
-    }
-
-    @Test
-    public void testTrackGoalInvalidId() throws Exception {
-        track().goal(-1).revenue(100f).with(mTracker);
-        verify(mTracker, never()).track(mCaptor.capture());
     }
 
     @Test

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/TrackHelperTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/TrackHelperTest.java
@@ -20,6 +20,8 @@ import java.net.URL;
 import java.util.Locale;
 import java.util.UUID;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -89,7 +91,7 @@ public class TrackHelperTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testOutlink_invalid_url() throws MalformedURLException {
-        track().outlink(new URL("file://mount/sdcard/something"));
+        track().outlink(new URL("file://mount/sdcard/something")).build();
     }
 
     @Test
@@ -195,6 +197,11 @@ public class TrackHelperTest {
         assertNull(CustomDimension.getDimension(mCaptor.getValue(), 4));
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetScreem_empty_path() throws Exception {
+        TrackHelper.track().screen((String) null).build();
+    }
+
     @Test
     public void testCustomDimension_trackHelperAny() {
         TrackHelper.track()
@@ -295,7 +302,7 @@ public class TrackHelperTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testTrackGoal_invalid_id() throws Exception {
-        track().goal(-1).revenue(100f);
+        track().goal(-1).revenue(100f).build();
     }
 
     @Test
@@ -335,17 +342,44 @@ public class TrackHelperTest {
         assertEquals(mCaptor.getValue().get(QueryParams.CONTENT_TARGET), "test2");
     }
 
-    @Test
-    public void testTrackContentInteraction() throws Exception {
-        String interaction = "interaction";
-        String name = "test name2";
-        track().interaction(name, interaction).piece("test").target("test2").with(mTracker);
-        verify(mTracker).track(mCaptor.capture());
+    @Test(expected = IllegalArgumentException.class)
+    public void testTrackContentImpression_invalid_name_empty() throws Exception {
+        track().impression("").build();
+    }
 
-        assertEquals(mCaptor.getValue().get(QueryParams.CONTENT_INTERACTION), interaction);
-        assertEquals(mCaptor.getValue().get(QueryParams.CONTENT_NAME), name);
-        assertEquals(mCaptor.getValue().get(QueryParams.CONTENT_PIECE), "test");
-        assertEquals(mCaptor.getValue().get(QueryParams.CONTENT_TARGET), "test2");
+    @Test(expected = IllegalArgumentException.class)
+    public void testTrackContentImpression_invalid_name_null() throws Exception {
+        track().impression(null).build();
+    }
+
+    @Test
+    public void testTrackContentInteraction_invalid_name_empty() throws Exception {
+        int errorCount = 0;
+        try {
+            track().interaction("", "test").piece("test").target("test2").build();
+        } catch (IllegalArgumentException e) { errorCount++; }
+        try {
+            track().interaction("test", "").piece("test").target("test2").build();
+        } catch (IllegalArgumentException e) { errorCount++; }
+        try {
+            track().interaction("", "").piece("test").target("test2").build();
+        } catch (IllegalArgumentException e) { errorCount++; }
+        assertThat(errorCount, is(3));
+    }
+
+    @Test
+    public void testTrackContentInteraction_invalid_name_null() throws Exception {
+        int errorCount = 0;
+        try {
+            track().interaction(null, "test").piece("test").target("test2").build();
+        } catch (IllegalArgumentException e) { errorCount++; }
+        try {
+            track().interaction("test", null).piece("test").target("test2").build();
+        } catch (IllegalArgumentException e) { errorCount++; }
+        try {
+            track().interaction(null, null).piece("test").target("test2").build();
+        } catch (IllegalArgumentException e) { errorCount++; }
+        assertThat(errorCount, is(3));
     }
 
     @Test


### PR DESCRIPTION
PR regarding discussion in #163 

> Builder pattern should not require a null-check by default, use exception where necessary.