### PR TITLE
Java8, Lints and #174

### DIFF
--- a/exampleapp/build.gradle
+++ b/exampleapp/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation project(":piwik-sdk")
     implementation "com.android.support:appcompat-v7:${supportLibVersion}"
     implementation "com.android.support:support-v4:${supportLibVersion}"
+    implementation "com.jakewharton.timber:timber:${timberVersion}"
     implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
 }

--- a/exampleapp/src/main/java/com/piwik/demo/DemoActivity.java
+++ b/exampleapp/src/main/java/com/piwik/demo/DemoActivity.java
@@ -9,7 +9,7 @@ package com.piwik.demo;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
+import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -27,7 +27,7 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 
 
-public class DemoActivity extends ActionBarActivity {
+public class DemoActivity extends AppCompatActivity {
     int cartItems = 0;
     private EcommerceItems items;
 

--- a/piwik-sdk/build.gradle
+++ b/piwik-sdk/build.gradle
@@ -16,12 +16,18 @@ android {
         versionCode myVersionCode
         versionName myVersionName
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
 }
 
 dependencies {
     implementation "com.android.support:support-annotations:${supportLibVersion}"
     implementation "com.jakewharton.timber:timber:${timberVersion}"
 
+    testImplementation 'org.awaitility:awaitility:3.0.0'
     // Robolectric
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.hamcrest:hamcrest-core:1.3'

--- a/piwik-sdk/src/main/java/org/piwik/sdk/Piwik.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Piwik.java
@@ -7,6 +7,7 @@
 
 package org.piwik.sdk;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
@@ -28,11 +29,12 @@ public class Piwik {
     public static final String LOGGER_PREFIX = "PIWIK:";
     private static final String LOGGER_TAG = "PIWIK";
     private static final String BASE_PREFERENCE_FILE = "org.piwik.sdk";
+
+    @SuppressLint("StaticFieldLeak") private static Piwik sInstance;
+
     private final Map<Tracker, SharedPreferences> mPreferenceMap = new HashMap<>();
     private final Context mContext;
-
-    private static Piwik sInstance;
-    private SharedPreferences mBasePreferences;
+    private final SharedPreferences mBasePreferences;
     private DispatcherFactory mDispatcherFactory = new DefaultDispatcherFactory();
 
     public static synchronized Piwik getInstance(Context context) {
@@ -84,7 +86,7 @@ public class Piwik {
                 try {
                     prefName = "org.piwik.sdk_" + Checksum.getMD5Checksum(tracker.getName());
                 } catch (Exception e) {
-                    Timber.tag(LOGGER_TAG).e(e, null);
+                    Timber.tag(LOGGER_TAG).e(e);
                     prefName = "org.piwik.sdk_" + tracker.getName();
                 }
                 newPrefs = getContext().getSharedPreferences(prefName, Context.MODE_PRIVATE);

--- a/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/Tracker.java
@@ -470,7 +470,7 @@ public class Tracker {
             try {
                 // Another thread might be creating a sessions first transmission.
                 mSessionStartLatch.await(mDispatcher.getConnectionTimeOut(), TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) { Timber.tag(TAG).e(e, null); }
+            } catch (InterruptedException e) { Timber.tag(TAG).e(e); }
         }
 
         injectBaseParams(trackMe);

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/DefaultDispatcher.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/DefaultDispatcher.java
@@ -152,7 +152,7 @@ public class DefaultDispatcher implements Dispatcher {
         if (mDispatchInterval != -1) launch();
     }
 
-    private Runnable mLoop = new Runnable() {
+    private final Runnable mLoop = new Runnable() {
         @Override
         public void run() {
             mRetryCounter = 0;

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/DefaultPacketSender.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/DefaultPacketSender.java
@@ -59,7 +59,7 @@ public class DefaultPacketSender implements PacketSender {
 
             return checkResponseCode(statusCode);
         } catch (Exception e) {
-            Timber.tag(LOGGER_TAG).e("Sending failed: %s", e);
+            Timber.tag(LOGGER_TAG).e(e, "Sending failed");
             return false;
         } finally {
             if (urlConnection != null) urlConnection.disconnect();

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/EventDiskCache.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/EventDiskCache.java
@@ -69,7 +69,7 @@ public class EventDiskCache {
                     final String[] split = head.getName().split("_");
                     timestamp = Long.valueOf(split[1]);
                 } catch (Exception e) {
-                    Timber.tag(TAG).e(e, null);
+                    Timber.tag(TAG).e(e);
                     timestamp = 0;
                 }
                 if (timestamp < (System.currentTimeMillis() - mMaxAge)) {
@@ -170,13 +170,13 @@ public class EventDiskCache {
 
                     String query = line.substring(split + 1);
                     events.add(new Event(timestamp, query));
-                } catch (Exception e) { Timber.tag(TAG).e(e, null); }
+                } catch (Exception e) { Timber.tag(TAG).e(e); }
             }
         } catch (IOException e) {
-            Timber.tag(TAG).e(e, null);
+            Timber.tag(TAG).e(e);
         } finally {
             if (in != null) {
-                try { in.close(); } catch (IOException e) { Timber.tag(TAG).e(e, null); }
+                try { in.close(); } catch (IOException e) { Timber.tag(TAG).e(e); }
             }
         }
 
@@ -202,12 +202,12 @@ public class EventDiskCache {
                 dataWritten = true;
             }
         } catch (IOException e) {
-            Timber.tag(TAG).e(e, null);
+            Timber.tag(TAG).e(e);
             newFile.deleteOnExit();
             return null;
         } finally {
             if (out != null) {
-                try { out.close(); } catch (IOException e) { Timber.tag(TAG).e(e, null); }
+                try { out.close(); } catch (IOException e) { Timber.tag(TAG).e(e); }
             }
         }
 

--- a/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/PacketFactory.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/dispatcher/PacketFactory.java
@@ -84,7 +84,7 @@ public class PacketFactory {
         try {
             return new Packet(new URL(mApiUrl.toString() + event));
         } catch (MalformedURLException e) {
-            Timber.tag(LOGGER_TAG).w(e, null);
+            Timber.tag(LOGGER_TAG).w(e);
         }
         return null;
     }

--- a/piwik-sdk/src/main/java/org/piwik/sdk/extra/DownloadTracker.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/extra/DownloadTracker.java
@@ -162,12 +162,9 @@ public class DownloadTracker {
             // Delay tracking incase we were called from within Application.onCreate
             Timber.tag(LOGGER_TAG).d("Google Play is install source, deferring tracking.");
         }
-        final Thread trackTask = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                if (delay) try {Thread.sleep(3000);} catch (Exception e) { Timber.tag(TAG).e(e, null);}
-                trackNewAppDownloadInternal(baseTrackme, extra);
-            }
+        final Thread trackTask = new Thread(() -> {
+            if (delay) try {Thread.sleep(3000);} catch (Exception e) { Timber.tag(TAG).e(e);}
+            trackNewAppDownloadInternal(baseTrackme, extra);
         });
         if (!delay && !extra.isIntensiveWork()) trackTask.run();
         else trackTask.start();

--- a/piwik-sdk/src/main/java/org/piwik/sdk/extra/EcommerceItems.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/extra/EcommerceItems.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class EcommerceItems {
-    private Map<String, JSONArray> mItems = new HashMap<>();
+    private final Map<String, JSONArray> mItems = new HashMap<>();
 
     /**
      * Adds a product into the ecommerce order. Must be called for each product in the order.

--- a/piwik-sdk/src/main/java/org/piwik/sdk/extra/PiwikApplication.java
+++ b/piwik-sdk/src/main/java/org/piwik/sdk/extra/PiwikApplication.java
@@ -8,7 +8,6 @@
 package org.piwik.sdk.extra;
 
 import android.app.Application;
-import android.os.Build;
 
 import org.piwik.sdk.Piwik;
 import org.piwik.sdk.Tracker;
@@ -41,9 +40,7 @@ public abstract class PiwikApplication extends Application {
 
     @Override
     public void onLowMemory() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH && mPiwikTracker != null) {
-            mPiwikTracker.dispatch();
-        }
+        if (mPiwikTracker != null) mPiwikTracker.dispatch();
         super.onLowMemory();
     }
 

--- a/piwik-sdk/src/test/java/org/piwik/sdk/LegacySettingsPorterTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/LegacySettingsPorterTest.java
@@ -6,16 +6,17 @@ import android.content.SharedPreferences;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import testhelpers.BaseTest;
+
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -24,26 +25,25 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @SuppressLint("CommitPrefEdits")
-public class LegacySettingsPorterTest {
+@RunWith(MockitoJUnitRunner.class)
+public class LegacySettingsPorterTest extends BaseTest {
     @Mock Piwik mPiwik;
-    private LegacySettingsPorter mPorter;
     @Mock SharedPreferences mPiwikPrefs;
     @Mock SharedPreferences.Editor mPiwikPrefsEditor;
     @Mock SharedPreferences mTrackerPrefs;
     @Mock SharedPreferences.Editor mTrackerPrefsEditor;
     @Mock Tracker mTracker;
+    private LegacySettingsPorter mPorter;
 
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
         when(mPiwikPrefs.edit()).thenReturn(mPiwikPrefsEditor);
         when(mPiwikPrefsEditor.remove(anyString())).thenReturn(mPiwikPrefsEditor);
 
         when(mTrackerPrefs.edit()).thenReturn(mTrackerPrefsEditor);
         when(mTrackerPrefsEditor.putBoolean(anyString(), anyBoolean())).thenReturn(mTrackerPrefsEditor);
         when(mTrackerPrefsEditor.putLong(anyString(), anyLong())).thenReturn(mTrackerPrefsEditor);
-        when(mTrackerPrefsEditor.putInt(anyString(), anyInt())).thenReturn(mTrackerPrefsEditor);
         when(mTrackerPrefsEditor.putString(anyString(), anyString())).thenReturn(mTrackerPrefsEditor);
 
         when(mPiwik.getPiwikPreferences()).thenReturn(mPiwikPrefs);
@@ -158,12 +158,7 @@ public class LegacySettingsPorterTest {
     @Test
     public void testDownloadMapping_empty() {
         final Map<String, ?> map = new HashMap<>();
-        when(mPiwikPrefs.getAll()).thenAnswer(new Answer<Map<String, ?>>() {
-            @Override
-            public Map<String, ?> answer(InvocationOnMock invocation) throws Throwable {
-                return map;
-            }
-        });
+        when(mPiwikPrefs.getAll()).thenAnswer((Answer<Map<String, ?>>) invocation -> map);
         mPorter.port(mTracker);
 
         verify(mPiwikPrefs).getAll();
@@ -180,12 +175,7 @@ public class LegacySettingsPorterTest {
         String key3 = "testkey2";
         map.put(key3, 123465);
 
-        when(mPiwikPrefs.getAll()).thenAnswer(new Answer<Map<String, ?>>() {
-            @Override
-            public Map<String, ?> answer(InvocationOnMock invocation) throws Throwable {
-                return map;
-            }
-        });
+        when(mPiwikPrefs.getAll()).thenAnswer((Answer<Map<String, ?>>) invocation -> map);
         mPorter.port(mTracker);
 
         verify(mPiwikPrefs).getAll();

--- a/piwik-sdk/src/test/java/org/piwik/sdk/PiwikTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/PiwikTest.java
@@ -22,11 +22,13 @@ import org.piwik.sdk.dispatcher.Packet;
 import org.piwik.sdk.dispatcher.PacketFactory;
 import org.piwik.sdk.dispatcher.PacketSender;
 import org.piwik.sdk.extra.TrackHelper;
-import org.piwik.sdk.testhelper.FullEnvTestRunner;
-import org.piwik.sdk.testhelper.PiwikTestApplication;
 import org.piwik.sdk.tools.Connectivity;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
+
+import testhelpers.BaseTest;
+import testhelpers.FullEnvTestRunner;
+import testhelpers.PiwikTestApplication;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -44,7 +46,7 @@ import static org.mockito.Mockito.when;
 
 @Config(emulateSdk = 18, manifest = Config.NONE)
 @RunWith(FullEnvTestRunner.class)
-public class PiwikTest {
+public class PiwikTest extends BaseTest {
 
     @Test
     public void testNewTracker() throws Exception {

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackMeTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackMeTest.java
@@ -1,10 +1,14 @@
 package org.piwik.sdk;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -13,7 +17,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
-public class TrackMeTest {
+@RunWith(MockitoJUnitRunner.class)
+public class TrackMeTest extends BaseTest {
     @Test
     public void testSourcingFromOtherTrackMe() throws Exception {
         TrackMe base = new TrackMe();

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerConfigTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerConfigTest.java
@@ -1,14 +1,19 @@
 package org.piwik.sdk;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import testhelpers.BaseTest;
+
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-public class TrackerConfigTest {
+@RunWith(MockitoJUnitRunner.class)
+public class TrackerConfigTest extends BaseTest {
 
     @Test
     public void testURL() throws MalformedURLException {

--- a/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/TrackerTest.java
@@ -9,13 +9,10 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.piwik.sdk.dispatcher.DispatchMode;
 import org.piwik.sdk.dispatcher.Dispatcher;
 import org.piwik.sdk.dispatcher.DispatcherFactory;
 import org.piwik.sdk.extra.TrackHelper;
-import org.piwik.sdk.testhelper.TestPreferences;
 import org.piwik.sdk.tools.DeviceHelper;
 
 import java.net.MalformedURLException;
@@ -25,6 +22,9 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+
+import testhelpers.TestHelper;
+import testhelpers.TestPreferences;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -318,30 +318,20 @@ public class TrackerTest {
     public void testSetNewSessionRaceCondition() throws Exception {
         for (int retry = 0; retry < 5; retry++) {
             final List<TrackMe> trackMes = Collections.synchronizedList(new ArrayList<TrackMe>());
-            doAnswer(new Answer<Void>() {
-                @Override
-                public Void answer(InvocationOnMock invocation) throws Throwable {
-                    trackMes.add((TrackMe) invocation.getArgument(0));
-                    return null;
-                }
+            doAnswer(invocation -> {
+                trackMes.add(invocation.getArgument(0));
+                return null;
             }).when(mDispatcher).submit(any(TrackMe.class));
             final Tracker tracker = new Tracker(mPiwik, mTrackerConfig);
             tracker.setDispatchInterval(0);
             int count = 20;
             for (int i = 0; i < count; i++) {
-                new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            Thread.sleep(10);
-                        } catch (InterruptedException e) {
-                            e.printStackTrace();
-                        }
-                        TrackHelper.track().screen("Test").with(tracker);
-                    }
+                new Thread(() -> {
+                    TestHelper.sleep(10);
+                    TrackHelper.track().screen("Test").with(tracker);
                 }).start();
             }
-            Thread.sleep(500);
+            TestHelper.sleep(500);
             assertEquals(count, trackMes.size());
             int found = 0;
             for (TrackMe trackMe : trackMes) {
@@ -359,7 +349,7 @@ public class TrackerTest {
         assertFalse(mTracker.tryNewSession());
 
         mTracker.setSessionTimeout(0);
-        Thread.sleep(1, 0);
+        TestHelper.sleep(1);
         assertTrue(mTracker.tryNewSession());
 
         mTracker.setSessionTimeout(10000);
@@ -373,7 +363,7 @@ public class TrackerTest {
         TrackHelper.track().screen("test").with(mTracker);
         verify(mDispatcher).submit(mCaptor.capture());
         assertEquals("1", mCaptor.getValue().get(QueryParams.SESSION_START));
-        Thread.sleep(1, 0);
+        TestHelper.sleep(1);
         TrackHelper.track().screen("test").with(mTracker);
         verify(mDispatcher, times(2)).submit(mCaptor.capture());
         assertEquals("1", mCaptor.getValue().get(QueryParams.SESSION_START));
@@ -435,7 +425,7 @@ public class TrackerTest {
         TrackHelper.track().event("TestCategory", "TestAction").with(mTracker);
         verify(mDispatcher).submit(mCaptor.capture());
         TrackMe trackMe1 = mCaptor.getValue();
-        Thread.sleep(10);
+        TestHelper.sleep(10);
         // make sure we are tracking in seconds
         assertTrue(Math.abs((System.currentTimeMillis() / 1000) - Long.parseLong(trackMe1.get(FIRST_VISIT_TIMESTAMP))) < 2);
 
@@ -470,15 +460,10 @@ public class TrackerTest {
         int threadCount = 1000;
         final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
         for (int i = 0; i < threadCount; i++) {
-            new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        Thread.sleep(new Random().nextInt(20 - 0) + 0);
-                    } catch (InterruptedException e) { e.printStackTrace(); }
-                    TrackHelper.track().event("TestCategory", "TestAction").with(new Tracker(mPiwik, mTrackerConfig));
-                    countDownLatch.countDown();
-                }
+            new Thread(() -> {
+                TestHelper.sleep(new Random().nextInt(20 - 0) + 0);
+                TrackHelper.track().event("TestCategory", "TestAction").with(new Tracker(mPiwik, mTrackerConfig));
+                countDownLatch.countDown();
             }).start();
         }
         countDownLatch.await();
@@ -488,12 +473,9 @@ public class TrackerTest {
     @Test
     public void testSessionStartRaceCondition() throws Exception {
         final List<TrackMe> trackMes = Collections.synchronizedList(new ArrayList<TrackMe>());
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                trackMes.add((TrackMe) invocation.getArgument(0));
-                return null;
-            }
+        doAnswer(invocation -> {
+            trackMes.add(invocation.getArgument(0));
+            return null;
         }).when(mDispatcher).submit(any(TrackMe.class));
         when(mDispatcher.getConnectionTimeOut()).thenReturn(1000);
         for (int i = 0; i < 1000; i++) {
@@ -501,22 +483,19 @@ public class TrackerTest {
             final Tracker tracker = new Tracker(mPiwik, mTrackerConfig);
             final CountDownLatch countDownLatch = new CountDownLatch(10);
             for (int j = 0; j < 10; j++) {
-                new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            Thread.sleep(new Random().nextInt(4 - 0) + 0);
-                            TrackMe trackMe = new TrackMe()
-                                    .set(QueryParams.EVENT_ACTION, UUID.randomUUID().toString())
-                                    .set(QueryParams.EVENT_CATEGORY, UUID.randomUUID().toString())
-                                    .set(QueryParams.EVENT_NAME, UUID.randomUUID().toString())
-                                    .set(QueryParams.EVENT_VALUE, 1);
-                            tracker.track(trackMe);
-                            countDownLatch.countDown();
-                        } catch (Exception e) {
-                            e.printStackTrace();
-                            assertFalse(true);
-                        }
+                new Thread(() -> {
+                    try {
+                        TestHelper.sleep(new Random().nextInt(4 - 0) + 0);
+                        TrackMe trackMe = new TrackMe()
+                                .set(QueryParams.EVENT_ACTION, UUID.randomUUID().toString())
+                                .set(QueryParams.EVENT_CATEGORY, UUID.randomUUID().toString())
+                                .set(QueryParams.EVENT_NAME, UUID.randomUUID().toString())
+                                .set(QueryParams.EVENT_VALUE, 1);
+                        tracker.track(trackMe);
+                        countDownLatch.countDown();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        assertFalse(true);
                     }
                 }).start();
             }
@@ -541,20 +520,12 @@ public class TrackerTest {
         final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
         final List<Long> firstVisitTimes = Collections.synchronizedList(new ArrayList<Long>());
         for (int i = 0; i < threadCount; i++) {
-            new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-
-                        Thread.sleep(new Random().nextInt(20 - 0) + 0);
-                        TrackHelper.track().event("TestCategory", "TestAction").with(mTracker);
-                        long firstVisit = Long.valueOf(mTracker.getDefaultTrackMe().get(FIRST_VISIT_TIMESTAMP));
-                        firstVisitTimes.add(firstVisit);
-                        countDownLatch.countDown();
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                }
+            new Thread(() -> {
+                TestHelper.sleep(new Random().nextInt(20 - 0) + 0);
+                TrackHelper.track().event("TestCategory", "TestAction").with(mTracker);
+                long firstVisit = Long.valueOf(mTracker.getDefaultTrackMe().get(FIRST_VISIT_TIMESTAMP));
+                firstVisitTimes.add(firstVisit);
+                countDownLatch.countDown();
             }).start();
         }
         countDownLatch.await();
@@ -571,7 +542,7 @@ public class TrackerTest {
             String previousVisit = mTracker.getDefaultTrackMe().get(QueryParams.PREVIOUS_VISIT_TIMESTAMP);
             if (previousVisit != null)
                 previousVisitTimes.add(Long.parseLong(previousVisit));
-            Thread.sleep(1010);
+            TestHelper.sleep(1010);
 
         }
         assertFalse(previousVisitTimes.contains(0L));
@@ -592,7 +563,7 @@ public class TrackerTest {
         long _startTime = System.currentTimeMillis() / 1000;
         // There was no previous visit
         assertNull(mCaptor.getValue().get(QueryParams.PREVIOUS_VISIT_TIMESTAMP));
-        Thread.sleep(1000);
+        TestHelper.sleep(1000);
 
         // After the first visit we now have a timestamp for the previous visit
         long previousVisit = mTracker.getPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
@@ -604,13 +575,13 @@ public class TrackerTest {
         // Transmitted timestamp is the one from the first visit visit
         assertEquals(previousVisit, Long.parseLong(mCaptor.getValue().get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
 
-        Thread.sleep(1000);
+        TestHelper.sleep(1000);
         mTracker = new Tracker(mPiwik, mTrackerConfig);
         TrackHelper.track().event("TestCategory", "TestAction").with(mTracker);
         verify(mDispatcher, times(3)).submit(mCaptor.capture());
         // Now the timestamp changed as this is the 3rd visit.
         assertNotEquals(previousVisit, Long.parseLong(mCaptor.getValue().get(QueryParams.PREVIOUS_VISIT_TIMESTAMP)));
-        Thread.sleep(1000);
+        TestHelper.sleep(1000);
 
         previousVisit = mTracker.getPreferences().getLong(Tracker.PREF_KEY_TRACKER_PREVIOUSVISIT, -1);
         mTracker = new Tracker(mPiwik, mTrackerConfig);

--- a/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/DefaultPacketSenderTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/DefaultPacketSenderTest.java
@@ -5,14 +5,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.io.IOException;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import testhelpers.BaseTest;
+import testhelpers.TestHelper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
@@ -22,20 +22,22 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class DefaultPacketSenderTest {
+public class DefaultPacketSenderTest extends BaseTest {
 
     DefaultPacketSender mDefaultPacketSender;
     MockWebServer mMockWebServer;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
+        super.setup();
         mDefaultPacketSender = new DefaultPacketSender();
         mMockWebServer = new MockWebServer();
     }
 
     @After
-    public void tearDown() throws IOException {
+    public void tearDown() throws Exception {
         mMockWebServer.close();
+        super.tearDown();
     }
 
     @Test
@@ -91,7 +93,7 @@ public class DefaultPacketSenderTest {
         mMockWebServer.setDispatcher(new Dispatcher() {
             @Override
             public MockResponse dispatch(RecordedRequest recordedRequest) throws InterruptedException {
-                Thread.sleep(100);
+                TestHelper.sleep(100);
                 return new MockResponse();
             }
         });

--- a/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/EventCacheTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/EventCacheTest.java
@@ -3,14 +3,17 @@ package org.piwik.sdk.dispatcher;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -21,15 +24,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class EventCacheTest {
+@RunWith(MockitoJUnitRunner.class)
+public class EventCacheTest extends BaseTest {
 
-    EventCache mEventCache;
     @Mock EventDiskCache mEventDiskCache;
+    EventCache mEventCache;
 
     @Before
     public void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
-
+        super.setup();
         when(mEventDiskCache.isEmpty()).thenReturn(true);
         mEventCache = spy(new EventCache(mEventDiskCache));
     }
@@ -71,7 +74,6 @@ public class EventCacheTest {
     @Test
     public void testDrain_diskCache_nonempty() throws Exception {
         List<Event> events = new ArrayList<>();
-        when(mEventDiskCache.isEmpty()).thenReturn(false);
         when(mEventDiskCache.uncache()).thenReturn(Collections.singletonList(new Event("test")));
         mEventCache.updateState(true);
         mEventCache.drainTo(events);
@@ -83,7 +85,6 @@ public class EventCacheTest {
     public void testDrain_diskCache_first() throws Exception {
         mEventCache.add(new Event("3"));
         List<Event> events = new ArrayList<>();
-        when(mEventDiskCache.isEmpty()).thenReturn(false);
         when(mEventDiskCache.uncache()).thenReturn(Arrays.asList(new Event("1"), new Event("2")));
         mEventCache.updateState(true);
         mEventCache.drainTo(events);
@@ -98,7 +99,6 @@ public class EventCacheTest {
     public void testUpdateState_online() throws Exception {
         verify(mEventDiskCache, never()).uncache();
         mEventCache.updateState(true);
-        when(mEventDiskCache.isEmpty()).thenReturn(false);
         mEventCache.updateState(true);
         verify(mEventDiskCache, times(2)).uncache();
     }
@@ -109,13 +109,13 @@ public class EventCacheTest {
         mEventCache.add(new Event("test"));
         assertFalse(mEventCache.isEmpty());
         mEventCache.updateState(false);
-        verify(mEventDiskCache).cache(ArgumentMatchers.<Event>anyList());
+        verify(mEventDiskCache).cache(ArgumentMatchers.anyList());
 
         mEventCache.updateState(false);
-        verify(mEventDiskCache).cache(ArgumentMatchers.<Event>anyList());
+        verify(mEventDiskCache).cache(ArgumentMatchers.anyList());
         mEventCache.add(new Event("test"));
         mEventCache.updateState(false);
-        verify(mEventDiskCache, times(2)).cache(ArgumentMatchers.<Event>anyList());
+        verify(mEventDiskCache, times(2)).cache(ArgumentMatchers.anyList());
     }
 
     @Test
@@ -123,7 +123,6 @@ public class EventCacheTest {
         assertTrue(mEventCache.isEmpty());
         mEventCache.add(new Event("test2"));
         when(mEventDiskCache.uncache()).thenReturn(Arrays.asList(new Event("test0"), new Event("test1")));
-        when(mEventDiskCache.isEmpty()).thenReturn(false);
         mEventCache.updateState(true);
 
         List<Event> restoredEvents = new ArrayList<>();

--- a/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/EventTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/EventTest.java
@@ -9,6 +9,8 @@ package org.piwik.sdk.dispatcher;
 import android.util.Pair;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.piwik.sdk.QueryParams;
 import org.piwik.sdk.TrackMe;
 import org.piwik.sdk.tools.UrlHelper;
@@ -19,9 +21,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import testhelpers.BaseTest;
+
 import static org.junit.Assert.assertEquals;
 
-public class EventTest {
+@RunWith(MockitoJUnitRunner.class)
+public class EventTest extends BaseTest {
     @Test
     public void testhashCode() {
         Event event = new Event(0, "");

--- a/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/PacketFactoryTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/PacketFactoryTest.java
@@ -1,6 +1,8 @@
 package org.piwik.sdk.dispatcher;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.net.URL;
 import java.util.Arrays;
@@ -8,12 +10,15 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
+import testhelpers.BaseTest;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class PacketFactoryTest {
+@RunWith(MockitoJUnitRunner.class)
+public class PacketFactoryTest extends BaseTest {
 
     @Test
     public void testPOST_apiUrl() throws Exception {
@@ -51,7 +56,7 @@ public class PacketFactoryTest {
     @Test
     public void testEmptyEvents() throws Exception {
         PacketFactory factory = new PacketFactory(new URL("http://example.com/"));
-        assertTrue(factory.buildPackets(Collections.<Event>emptyList()).isEmpty());
+        assertTrue(factory.buildPackets(Collections.emptyList()).isEmpty());
     }
 
     @Test

--- a/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/PacketTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/dispatcher/PacketTest.java
@@ -1,23 +1,20 @@
 package org.piwik.sdk.dispatcher;
 
 
-import org.junit.Before;
 import org.junit.Test;
-import org.mockito.MockitoAnnotations;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import java.io.IOException;
 import java.net.URL;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class PacketTest {
+@RunWith(MockitoJUnitRunner.class)
+public class PacketTest extends BaseTest {
     URL mUrl;
-
-    @Before
-    public void setup() throws IOException {
-        MockitoAnnotations.initMocks(this);
-    }
 
     @Test
     public void testEventCount() {

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/CustomDimensionTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/CustomDimensionTest.java
@@ -1,16 +1,21 @@
 package org.piwik.sdk.extra;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.piwik.sdk.TrackMe;
 
 import java.util.UUID;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class CustomDimensionTest {
+@RunWith(MockitoJUnitRunner.class)
+public class CustomDimensionTest extends BaseTest {
 
     @Test
     public void testSetCustomDimensions() throws Exception {

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/CustomVariablesTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/CustomVariablesTest.java
@@ -4,16 +4,21 @@ import org.apache.maven.artifact.ant.shaded.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.piwik.sdk.QueryParams;
 import org.piwik.sdk.TrackMe;
 
 import java.util.Arrays;
 
+import testhelpers.BaseTest;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("deprecation")
-public class CustomVariablesTest {
+@RunWith(MockitoJUnitRunner.class)
+public class CustomVariablesTest extends BaseTest {
 
     @Test
     public void testPutAll() throws Exception {

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/DownloadTrackerTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/DownloadTrackerTest.java
@@ -8,20 +8,24 @@ import android.content.pm.PackageManager;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.piwik.sdk.Piwik;
 import org.piwik.sdk.QueryParams;
 import org.piwik.sdk.TrackMe;
 import org.piwik.sdk.Tracker;
-import org.piwik.sdk.testhelper.TestPreferences;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import testhelpers.BaseTest;
+import testhelpers.TestHelper;
+import testhelpers.TestPreferences;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -31,18 +35,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class DownloadTrackerTest {
-    ArgumentCaptor<TrackMe> mCaptor = ArgumentCaptor.forClass(TrackMe.class);
+@RunWith(MockitoJUnitRunner.class)
+public class DownloadTrackerTest extends BaseTest {
     @Mock Tracker mTracker;
     @Mock Piwik mPiwik;
     @Mock Context mContext;
     @Mock PackageManager mPackageManager;
+    ArgumentCaptor<TrackMe> mCaptor = ArgumentCaptor.forClass(TrackMe.class);
     SharedPreferences mSharedPreferences = new TestPreferences();
     private PackageInfo mPackageInfo;
 
     @Before
     public void setup() throws PackageManager.NameNotFoundException {
-        MockitoAnnotations.initMocks(this);
         when(mTracker.getPreferences()).thenReturn(mSharedPreferences);
         when(mTracker.getPiwik()).thenReturn(mPiwik);
         when(mPiwik.getContext()).thenReturn(mContext);
@@ -87,7 +91,7 @@ public class DownloadTrackerTest {
 
         DownloadTracker downloadTracker = new DownloadTracker(mTracker);
         downloadTracker.trackNewAppDownload(new TrackMe(), new DownloadTracker.Extra.ApkChecksum(mContext));
-        Thread.sleep(100); // APK checksum happens off thread
+        TestHelper.sleep(100); // APK checksum happens off thread
         verify(mTracker).track(mCaptor.capture());
         checkNewAppDownload(mCaptor.getValue());
         Matcher m = REGEX_DOWNLOADTRACK.matcher(mCaptor.getValue().get(QueryParams.DOWNLOAD));

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/EcommerceItemsTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/EcommerceItemsTest.java
@@ -2,13 +2,18 @@ package org.piwik.sdk.extra;
 
 import org.json.JSONArray;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Locale;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class EcommerceItemsTest {
+@RunWith(MockitoJUnitRunner.class)
+public class EcommerceItemsTest extends BaseTest {
 
     @Test
     public void testEmptyItems() throws Exception {

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/InstallReferrerReceiverTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/InstallReferrerReceiverTest.java
@@ -3,8 +3,9 @@ package org.piwik.sdk.extra;
 import android.content.Intent;
 
 import org.junit.Test;
-import org.piwik.sdk.testhelper.DefaultTestCase;
 import org.robolectric.Robolectric;
+
+import testhelpers.DefaultTestCase;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;

--- a/piwik-sdk/src/test/java/org/piwik/sdk/extra/PiwikApplicationTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/extra/PiwikApplicationTest.java
@@ -10,16 +10,16 @@ import org.junit.runner.RunWith;
 import org.piwik.sdk.Piwik;
 import org.piwik.sdk.QueryParams;
 import org.piwik.sdk.Tracker;
-import org.piwik.sdk.dispatcher.Packet;
-import org.piwik.sdk.testhelper.DefaultTestCase;
-import org.piwik.sdk.testhelper.FullEnvTestRunner;
-import org.piwik.sdk.testhelper.QueryHashMap;
-import org.piwik.sdk.testhelper.TestActivity;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.Collections;
+
+import testhelpers.DefaultTestCase;
+import testhelpers.FullEnvTestRunner;
+import testhelpers.QueryHashMap;
+import testhelpers.TestActivity;
 
 import static org.junit.Assert.assertEquals;
 
@@ -31,7 +31,7 @@ public class PiwikApplicationTest extends DefaultTestCase {
     public void testPiwikAutoBindActivities() throws Exception {
         Application app = Robolectric.application;
         Tracker tracker = createTracker();
-        tracker.setDryRunTarget(Collections.synchronizedList(new ArrayList<Packet>()));
+        tracker.setDryRunTarget(Collections.synchronizedList(new ArrayList<>()));
         //auto attach tracking screen view
         TrackHelper.track().screens(app).with(tracker);
 

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/BuildInfoTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/BuildInfoTest.java
@@ -4,16 +4,21 @@ import android.os.Build;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 
-
-public class BuildInfoTest {
+@RunWith(MockitoJUnitRunner.class)
+public class BuildInfoTest extends BaseTest {
 
     private BuildInfo mBuildInfo;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
+        super.setup();
         mBuildInfo = new BuildInfo();
     }
 

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/ChecksumTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/ChecksumTest.java
@@ -1,14 +1,19 @@
 package org.piwik.sdk.tools;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class ChecksumTest {
+@RunWith(MockitoJUnitRunner.class)
+public class ChecksumTest extends BaseTest {
 
     @Test
     public void testgetMD5Checksum() throws Exception {

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/ConnectivityTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/ConnectivityTest.java
@@ -6,23 +6,25 @@ import android.net.NetworkInfo;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ConnectivityTest {
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectivityTest extends BaseTest {
     @Mock Context mContext;
     @Mock ConnectivityManager mConnectivityManager;
     @Mock NetworkInfo mNetworkInfo;
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
         when(mContext.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(mConnectivityManager);
-
     }
 
     @Test

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/CurrencyFormatterTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/CurrencyFormatterTest.java
@@ -1,10 +1,15 @@
 package org.piwik.sdk.tools;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 
-public class CurrencyFormatterTest {
+@RunWith(MockitoJUnitRunner.class)
+public class CurrencyFormatterTest extends BaseTest {
 
     @Test
     public void testCurrencyFormat() throws Exception {

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/DeviceHelperTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/DeviceHelperTest.java
@@ -5,22 +5,26 @@ import android.content.Context;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import testhelpers.BaseTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class DeviceHelperTest {
+@RunWith(MockitoJUnitRunner.class)
+public class DeviceHelperTest extends BaseTest {
     @Mock PropertySource mPropertySource;
     @Mock BuildInfo mBuildInfo;
     @Mock Context mContext;
     private DeviceHelper mDeviceHelper;
 
     @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
+    public void setup() throws Exception {
+        super.setup();
         when(mBuildInfo.getBuildId()).thenReturn("ABCDEF");
         when(mBuildInfo.getModel()).thenReturn("UnitTest");
         when(mBuildInfo.getRelease()).thenReturn("8.0.0");

--- a/piwik-sdk/src/test/java/org/piwik/sdk/tools/PropertySourceTest.java
+++ b/piwik-sdk/src/test/java/org/piwik/sdk/tools/PropertySourceTest.java
@@ -2,12 +2,14 @@ package org.piwik.sdk.tools;
 
 import org.junit.Test;
 
+import testhelpers.BaseTest;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 
-public class PropertySourceTest {
+public class PropertySourceTest extends BaseTest {
     @Test
     public void testGetHttpAgent() {
         PropertySource propertySource = spy(new PropertySource());

--- a/piwik-sdk/src/test/java/testhelpers/BaseTest.java
+++ b/piwik-sdk/src/test/java/testhelpers/BaseTest.java
@@ -11,7 +11,6 @@ import timber.log.Timber;
 @RunWith(MockitoJUnitRunner.class)
 public class BaseTest {
 
-
     @Before
     public void setup() throws Exception {
         Timber.plant(new JUnitTree());

--- a/piwik-sdk/src/test/java/testhelpers/BaseTest.java
+++ b/piwik-sdk/src/test/java/testhelpers/BaseTest.java
@@ -1,0 +1,24 @@
+package testhelpers;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import timber.log.Timber;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaseTest {
+
+
+    @Before
+    public void setup() throws Exception {
+        Timber.plant(new JUnitTree());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Timber.uprootAll();
+    }
+}

--- a/piwik-sdk/src/test/java/testhelpers/BaseTest.java
+++ b/piwik-sdk/src/test/java/testhelpers/BaseTest.java
@@ -2,13 +2,10 @@ package testhelpers;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import timber.log.Timber;
 
 
-@RunWith(MockitoJUnitRunner.class)
 public class BaseTest {
 
     @Before

--- a/piwik-sdk/src/test/java/testhelpers/DefaultTestCase.java
+++ b/piwik-sdk/src/test/java/testhelpers/DefaultTestCase.java
@@ -1,6 +1,5 @@
-package org.piwik.sdk.testhelper;
+package testhelpers;
 
-import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.piwik.sdk.Piwik;
 import org.piwik.sdk.Tracker;
@@ -11,7 +10,7 @@ import java.net.MalformedURLException;
 
 @Config(emulateSdk = 18, manifest = Config.NONE)
 @RunWith(FullEnvTestRunner.class)
-public abstract class DefaultTestCase {
+public abstract class DefaultTestCase extends BaseTest {
     public Tracker createTracker() throws MalformedURLException {
         PiwikTestApplication app = (PiwikTestApplication) Robolectric.application;
         final Tracker tracker = Piwik.getInstance(Robolectric.application).newTracker(app.onCreateTrackerConfig());
@@ -23,8 +22,4 @@ public abstract class DefaultTestCase {
         return Piwik.getInstance(Robolectric.application);
     }
 
-    @Before
-    public void setup() {
-
-    }
 }

--- a/piwik-sdk/src/test/java/testhelpers/FullEnvPackageManager.java
+++ b/piwik-sdk/src/test/java/testhelpers/FullEnvPackageManager.java
@@ -5,7 +5,7 @@
  * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
  */
 
-package org.piwik.sdk.testhelper;
+package testhelpers;
 
 import android.content.ComponentName;
 import android.content.Intent;
@@ -33,7 +33,7 @@ public class FullEnvPackageManager extends RobolectricPackageManager {
     private final HashMap<String, String> mInstallerPackageNames = new HashMap<>();
 
     @Override
-    public Intent getLeanbackLaunchIntentForPackage(String packageName) {
+    public Intent getLeanbackLaunchIntentForPackage(@NonNull String packageName) {
         return null;
     }
 

--- a/piwik-sdk/src/test/java/testhelpers/FullEnvTestLifeCycle.java
+++ b/piwik-sdk/src/test/java/testhelpers/FullEnvTestLifeCycle.java
@@ -5,7 +5,7 @@
  * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
  */
 
-package org.piwik.sdk.testhelper;
+package testhelpers;
 
 import android.app.Application;
 import android.content.pm.PackageInfo;

--- a/piwik-sdk/src/test/java/testhelpers/FullEnvTestRunner.java
+++ b/piwik-sdk/src/test/java/testhelpers/FullEnvTestRunner.java
@@ -5,7 +5,7 @@
  * @license https://github.com/piwik/piwik-sdk-android/blob/master/LICENSE BSD-3 Clause
  */
 
-package org.piwik.sdk.testhelper;
+package testhelpers;
 
 import org.junit.runners.model.InitializationError;
 import org.robolectric.RobolectricTestRunner;

--- a/piwik-sdk/src/test/java/testhelpers/JUnitTree.java
+++ b/piwik-sdk/src/test/java/testhelpers/JUnitTree.java
@@ -1,0 +1,42 @@
+package testhelpers;
+
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import timber.log.Timber;
+
+
+public class JUnitTree extends Timber.DebugTree {
+    private final int minlogLevel;
+
+    public JUnitTree() {
+        minlogLevel = Log.VERBOSE;
+    }
+
+    public JUnitTree(int minlogLevel) {
+        this.minlogLevel = minlogLevel;
+    }
+
+    private static String priorityToString(int priority) {
+        switch (priority) {
+            case Log.ERROR:
+                return "E";
+            case Log.WARN:
+                return "W";
+            case Log.INFO:
+                return "I";
+            case Log.DEBUG:
+                return "D";
+            case Log.VERBOSE:
+                return "V";
+            default:
+                return String.valueOf(priority);
+        }
+    }
+
+    @Override
+    protected void log(int priority, String tag, @NonNull String message, Throwable t) {
+        if (priority < minlogLevel) return;
+        System.out.println(System.currentTimeMillis() + " " + priorityToString(priority) + "/" + tag + ": " + message);
+    }
+}

--- a/piwik-sdk/src/test/java/testhelpers/PiwikTestApplication.java
+++ b/piwik-sdk/src/test/java/testhelpers/PiwikTestApplication.java
@@ -1,4 +1,4 @@
-package org.piwik.sdk.testhelper;
+package testhelpers;
 
 
 import org.piwik.sdk.TrackerConfig;

--- a/piwik-sdk/src/test/java/testhelpers/QueryHashMap.java
+++ b/piwik-sdk/src/test/java/testhelpers/QueryHashMap.java
@@ -1,4 +1,4 @@
-package org.piwik.sdk.testhelper;
+package testhelpers;
 
 import org.piwik.sdk.QueryParams;
 import org.piwik.sdk.TrackMe;

--- a/piwik-sdk/src/test/java/testhelpers/TestActivity.java
+++ b/piwik-sdk/src/test/java/testhelpers/TestActivity.java
@@ -1,4 +1,4 @@
-package org.piwik.sdk.testhelper;
+package testhelpers;
 
 import android.app.Activity;
 import android.os.Bundle;

--- a/piwik-sdk/src/test/java/testhelpers/TestHelper.java
+++ b/piwik-sdk/src/test/java/testhelpers/TestHelper.java
@@ -1,0 +1,15 @@
+package testhelpers;
+
+import timber.log.Timber;
+
+public class TestHelper {
+
+    public static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            Timber.e(e);
+        }
+    }
+}

--- a/piwik-sdk/src/test/java/testhelpers/TestPreferences.java
+++ b/piwik-sdk/src/test/java/testhelpers/TestPreferences.java
@@ -1,4 +1,4 @@
-package org.piwik.sdk.testhelper;
+package testhelpers;
 
 import android.content.SharedPreferences;
 import android.support.annotation.Nullable;


### PR DESCRIPTION
* I've added a backoff mechanism to address #174 . If the transmission fails we start increasing the dispatch interval from the second failure on up to 5 times. I added unit tests for this and have rewritten a couple of other unit test in `DefaultDispatcherTest`. More mocking, less dependency on other classes.
```
Dispatchintervall=100ms
Send -> Fail -> Sleep 100ms -> RetryCnt=1
Send -> Fail -> Sleep 100ms -> RetryCnt=2
Send -> Fail -> Sleep 100ms + 2*100ms -> RetryCnt=3
Send -> Fail -> Sleep 100ms + 3*100ms -> RetryCnt=4
Send -> Fail -> Sleep 100ms + 4*100ms -> RetryCnt=5
Send -> Fail -> Sleep 100ms + 5*100ms -> RetryCnt=6
Send -> Fail -> Sleep 100ms + 5*100ms -> RetryCnt=7
etc.
```
* The current dev branch aims for a `3.0.0` release thus I think it's okay to make some breaking changes. We raised the minSDK in #177 too. As Android Studio 3.0+ introduces official use of Java8 features I think we can make use of them in this lib too. I've thus added
```
    compileOptions {
        sourceCompatibility JavaVersion.VERSION_1_8
        targetCompatibility JavaVersion.VERSION_1_8
    }
```
* Based on this change I went through the code and fixed LINTs.
* I refactored the unit tests to move the "Helper" classes out of the main package
* I made every class extend a `BaseTest` class which plants a `JUnitTree` so unit tests log into console too.